### PR TITLE
feat: rediseñar login y registro con fondo completo estilo luna y tar…

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -162,6 +162,7 @@
 
   /* ============================================================
      AUTH LAYOUT  –  Split: imagen izquierda | blanco derecha
+     (usado en Register.vue)
   ============================================================ */
 
   .auth-layout {
@@ -260,7 +261,6 @@
     @apply text-sm text-gray-400 mb-8;
   }
 
-  /* ── Campos ── */
   .auth-field {
     @apply flex flex-col gap-1.5;
   }
@@ -296,7 +296,6 @@
     @apply absolute right-3.5 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer;
   }
 
-  /* ── Botón ── */
   .auth-submit-btn {
     @apply w-full flex items-center justify-center py-3.5 px-4 rounded-xl font-bold text-sm text-white transition-all duration-200;
     background: linear-gradient(135deg, #dc2626 0%, #b91c1c 100%);
@@ -317,13 +316,144 @@
     @apply opacity-50 cursor-not-allowed;
   }
 
-  /* ── Footer ── */
   .auth-footer-text {
     @apply mt-6 text-center text-sm text-gray-400;
   }
 
   .auth-footer-link {
     @apply text-red-600 hover:text-red-700 font-semibold ml-1 transition-colors;
+  }
+
+  /* ============================================================
+     LOGIN – Fondo completo con tarjeta centrada (estilo luna)
+  ============================================================ */
+
+  /* Fondo con imagen de gimnasio a pantalla completa */
+  .login-bg {
+    @apply relative flex min-h-screen w-screen items-center justify-center overflow-y-auto;
+    background-image: url('/img/fondo_sin_letra.png');
+    background-size: cover;
+    background-position: center;
+    padding: 2rem 0;
+  }
+
+  /* Overlay gradiente luna: negro profundo abajo → azul noche arriba */
+  .login-overlay {
+    @apply absolute inset-0 pointer-events-none;
+    background: linear-gradient(
+      to top,
+      rgba(2, 3, 15, 0.97)  0%,
+      rgba(4,  8, 40, 0.91) 28%,
+      rgba(7, 15, 65, 0.82) 58%,
+      rgba(10, 22, 88, 0.66) 100%
+    );
+  }
+
+  /* Tarjeta glassmorphism centrada */
+  .login-card {
+    @apply relative z-10 w-full;
+    margin: 1rem;
+    max-width: 440px;
+    padding: 2.75rem 2.5rem;
+    border-radius: 1.5rem;
+    background: rgba(255, 255, 255, 0.055);
+    backdrop-filter: blur(28px);
+    -webkit-backdrop-filter: blur(28px);
+    border: 1px solid rgba(255, 255, 255, 0.13);
+    box-shadow:
+      0 40px 100px rgba(0, 0, 0, 0.60),
+      0 8px 24px rgba(0, 0, 0, 0.35),
+      inset 0 1px 0 rgba(255, 255, 255, 0.10);
+    animation: authFadeUp 0.7s ease-out both;
+  }
+
+  /* Logo */
+  .login-logo {
+    @apply text-center text-4xl font-black text-white mb-1;
+    letter-spacing: -0.03em;
+  }
+
+  .login-logo span {
+    @apply text-red-500;
+  }
+
+  /* Badge "Sistema de Gestión" */
+  .login-badge {
+    @apply flex items-center justify-center gap-1.5 mb-5 text-xs font-semibold tracking-widest uppercase;
+    color: #fca5a5;
+  }
+
+  .login-badge-dot {
+    @apply w-1.5 h-1.5 rounded-full bg-red-400;
+  }
+
+  /* Títulos */
+  .login-title {
+    @apply text-2xl font-bold text-white mb-1;
+    letter-spacing: -0.02em;
+  }
+
+  .login-subtitle {
+    @apply text-sm mb-8;
+    color: rgba(148, 163, 184, 0.9);
+  }
+
+  /* Labels en oscuro */
+  .login-label {
+    @apply text-xs font-semibold uppercase tracking-wider;
+    color: rgba(148, 163, 184, 0.85);
+  }
+
+  /* Ícono de campo */
+  .login-input-icon {
+    @apply absolute left-3.5 w-4 h-4 pointer-events-none;
+    color: rgba(100, 116, 139, 0.8);
+  }
+
+  /* Input en oscuro */
+  .login-input {
+    @apply w-full pl-10 pr-4 py-3 rounded-xl text-sm text-white outline-none transition-all duration-200;
+    background: rgba(255, 255, 255, 0.07);
+    border: 1.5px solid rgba(255, 255, 255, 0.12);
+  }
+
+  .login-input::placeholder {
+    color: rgba(255, 255, 255, 0.45);
+  }
+
+  .login-input:hover {
+    border-color: rgba(255, 255, 255, 0.22);
+  }
+
+  .login-input:focus {
+    background: rgba(255, 255, 255, 0.10);
+    border-color: #ef4444;
+    box-shadow: 0 0 0 3px rgba(239, 68, 68, 0.15);
+  }
+
+  /* Botón ojo contraseña */
+  .login-eye-btn {
+    @apply absolute right-3.5 transition-colors cursor-pointer;
+    color: rgba(100, 116, 139, 0.8);
+  }
+
+  .login-eye-btn:hover {
+    color: rgba(148, 163, 184, 1);
+  }
+
+  /* Footer del formulario */
+  .login-footer-text {
+    @apply mt-6 text-center text-sm;
+    color: rgba(100, 116, 139, 0.85);
+  }
+
+  .login-footer-link {
+    @apply font-semibold ml-1 transition-colors;
+    color: #f87171;
+  }
+
+  .login-footer-link:hover {
+    color: #ef4444;
   }
 }
 

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,93 +1,72 @@
 <template>
-  <div class="auth-layout">
+  <div class="login-bg">
 
-    <!-- Panel izquierdo: imagen + branding -->
-    <div class="auth-brand-panel">
-      <div class="auth-brand-overlay" />
-      <div class="auth-brand-content">
-        <div class="auth-brand-badge">
-          <span class="auth-brand-badge-dot" />
-          Sistema de Gestión
-        </div>
-        <h1 class="auth-brand-logo">COSMO<span>GYM</span></h1>
-        <p class="auth-brand-tagline">Transforma tu cuerpo,<br />transforma tu vida.</p>
-        <div class="auth-brand-stats">
-          <div>
-            <span class="auth-stat-num">500+</span>
-            <span class="auth-stat-label">Miembros</span>
-          </div>
-          <div class="auth-stat-divider" />
-          <div>
-            <span class="auth-stat-num">10+</span>
-            <span class="auth-stat-label">Planes</span>
-          </div>
-          <div class="auth-stat-divider" />
-          <div>
-            <span class="auth-stat-num">24/7</span>
-            <span class="auth-stat-label">Soporte</span>
-          </div>
-        </div>
+    <!-- Overlay gradiente luna -->
+    <div class="login-overlay" />
+
+    <!-- Tarjeta central flotante -->
+    <div class="login-card">
+
+      <!-- Logo -->
+      <div class="login-logo">COSMO<span>GYM</span></div>
+
+      <!-- Badge -->
+      <div class="login-badge">
+        <span class="login-badge-dot" />
+        Sistema de Gestión
       </div>
-    </div>
 
-    <!-- Panel derecho: formulario -->
-    <div class="auth-form-panel">
-      <div class="auth-form-card">
+      <h2 class="login-title">Bienvenido de nuevo</h2>
+      <p class="login-subtitle">Ingresa tus credenciales para continuar</p>
 
-        <div class="auth-mobile-logo">COSMO<span>GYM</span></div>
-        <h2 class="auth-form-title">Bienvenido de nuevo</h2>
-        <p class="auth-form-subtitle">Ingresa tus credenciales para continuar</p>
+      <form @submit.prevent="handleLogin" class="space-y-4">
 
-        <form @submit.prevent="handleLogin" class="space-y-4">
-
-          <div class="auth-field">
-            <label class="auth-label">Correo electrónico</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
-              </svg>
-              <input v-model="email" type="email" class="auth-input" placeholder="tu@correo.com" required />
-            </div>
+        <div class="auth-field">
+          <label class="login-label">Correo electrónico</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+            </svg>
+            <input v-model="email" type="email" class="login-input" placeholder="tu@correo.com" required />
           </div>
+        </div>
 
-          <div class="auth-field">
-            <label class="auth-label">Contraseña</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+        <div class="auth-field">
+          <label class="login-label">Contraseña</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+            </svg>
+            <input v-model="password" :type="showPassword ? 'text' : 'password'" class="login-input pr-11" placeholder="••••••••" required />
+            <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
+              <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              <input v-model="password" :type="showPassword ? 'text' : 'password'" class="auth-input pr-11" placeholder="••••••••" required />
-              <button type="button" class="auth-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
-                <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-                </svg>
-              </button>
-            </div>
-          </div>
-
-          <div class="pt-2">
-            <button type="submit" :disabled="loading" class="auth-submit-btn">
-              <svg v-if="loading" class="animate-spin mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+              <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
               </svg>
-              {{ loading ? 'Ingresando...' : 'Iniciar Sesión' }}
             </button>
           </div>
-        </form>
+        </div>
 
-        <p class="auth-footer-text">
-          ¿No tienes cuenta?
-          <router-link to="/register" class="auth-footer-link">Regístrate aquí</router-link>
-        </p>
+        <div class="pt-2">
+          <button type="submit" :disabled="loading" class="auth-submit-btn">
+            <svg v-if="loading" class="animate-spin mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            {{ loading ? 'Ingresando...' : 'Iniciar Sesión' }}
+          </button>
+        </div>
+      </form>
 
-      </div>
+      <p class="login-footer-text">
+        ¿No tienes cuenta?
+        <router-link to="/register" class="login-footer-link">Regístrate aquí</router-link>
+      </p>
+
     </div>
-
   </div>
 </template>
 

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -1,123 +1,102 @@
 <template>
-  <div class="auth-layout">
+  <div class="login-bg">
 
-    <!-- Panel izquierdo: imagen + branding -->
-    <div class="auth-brand-panel">
-      <div class="auth-brand-overlay" />
-      <div class="auth-brand-content">
-        <div class="auth-brand-badge">
-          <span class="auth-brand-badge-dot" />
-          Únete hoy
-        </div>
-        <h1 class="auth-brand-logo">COSMO<span>GYM</span></h1>
-        <p class="auth-brand-tagline">El primer paso hacia<br />tu mejor versión.</p>
-        <div class="auth-brand-stats">
-          <div>
-            <span class="auth-stat-num">500+</span>
-            <span class="auth-stat-label">Miembros</span>
-          </div>
-          <div class="auth-stat-divider" />
-          <div>
-            <span class="auth-stat-num">10+</span>
-            <span class="auth-stat-label">Planes</span>
-          </div>
-          <div class="auth-stat-divider" />
-          <div>
-            <span class="auth-stat-num">24/7</span>
-            <span class="auth-stat-label">Soporte</span>
-          </div>
-        </div>
+    <!-- Overlay gradiente luna -->
+    <div class="login-overlay" />
+
+    <!-- Tarjeta central flotante -->
+    <div class="login-card" style="max-width: 460px; padding: 2.25rem 2.5rem;">
+
+      <!-- Logo -->
+      <div class="login-logo">COSMO<span>GYM</span></div>
+
+      <!-- Badge -->
+      <div class="login-badge">
+        <span class="login-badge-dot" />
+        Únete hoy
       </div>
-    </div>
 
-    <!-- Panel derecho: formulario -->
-    <div class="auth-form-panel">
-      <div class="auth-form-card">
+      <h2 class="login-title">Crea tu cuenta</h2>
+      <p class="login-subtitle">Registra tu gimnasio y empieza a gestionar</p>
 
-        <div class="auth-mobile-logo">COSMO<span>GYM</span></div>
-        <h2 class="auth-form-title">Crea tu cuenta</h2>
-        <p class="auth-form-subtitle">Registra tu gimnasio y empieza a gestionar</p>
+      <form @submit.prevent="register" class="space-y-3.5">
 
-        <form @submit.prevent="register" class="space-y-4">
-
-          <div class="auth-field">
-            <label class="auth-label">Nombre completo</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-              </svg>
-              <input v-model="form.name" type="text" class="auth-input" placeholder="Tu nombre completo" required />
-            </div>
+        <div class="auth-field">
+          <label class="login-label">Nombre completo</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
+            </svg>
+            <input v-model="form.name" type="text" class="login-input" placeholder="Tu nombre completo" required />
           </div>
+        </div>
 
-          <div class="auth-field">
-            <label class="auth-label">Correo electrónico</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
-              </svg>
-              <input v-model="form.email" type="email" class="auth-input" placeholder="tu@correo.com" required />
-            </div>
+        <div class="auth-field">
+          <label class="login-label">Correo electrónico</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
+            </svg>
+            <input v-model="form.email" type="email" class="login-input" placeholder="tu@correo.com" required />
           </div>
+        </div>
 
-          <div class="auth-field">
-            <label class="auth-label">Nombre del Gimnasio</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
-              </svg>
-              <input v-model="form.gym_name" type="text" class="auth-input" placeholder="Nombre de tu gimnasio" required />
-            </div>
+        <div class="auth-field">
+          <label class="login-label">Nombre del Gimnasio</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
+            </svg>
+            <input v-model="form.gym_name" type="text" class="login-input" placeholder="Nombre de tu gimnasio" required />
           </div>
+        </div>
 
-          <div class="auth-field">
-            <label class="auth-label">Contraseña</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+        <div class="auth-field">
+          <label class="login-label">Contraseña</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
+            </svg>
+            <input v-model="form.password" :type="showPassword ? 'text' : 'password'" class="login-input pr-11" placeholder="••••••••" required />
+            <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
+              <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
+                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
               </svg>
-              <input v-model="form.password" :type="showPassword ? 'text' : 'password'" class="auth-input pr-11" placeholder="••••••••" required />
-              <button type="button" class="auth-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
-                <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                </svg>
-                <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-                </svg>
-              </button>
-            </div>
-          </div>
-
-          <div class="auth-field">
-            <label class="auth-label">Confirmar contraseña</label>
-            <div class="auth-input-wrap">
-              <svg class="auth-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+              <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
               </svg>
-              <input v-model="form.password_confirmation" :type="showPassword ? 'text' : 'password'" class="auth-input" placeholder="••••••••" required />
-            </div>
-          </div>
-
-          <div class="pt-2">
-            <button type="submit" :disabled="loading" class="auth-submit-btn">
-              <svg v-if="loading" class="animate-spin mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-              </svg>
-              {{ loading ? 'Creando cuenta...' : 'Crear Cuenta' }}
             </button>
           </div>
-        </form>
+        </div>
 
-        <p class="auth-footer-text">
-          ¿Ya tienes cuenta?
-          <router-link to="/" class="auth-footer-link">Inicia sesión</router-link>
-        </p>
+        <div class="auth-field">
+          <label class="login-label">Confirmar contraseña</label>
+          <div class="auth-input-wrap">
+            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
+            </svg>
+            <input v-model="form.password_confirmation" :type="showPassword ? 'text' : 'password'" class="login-input" placeholder="••••••••" required />
+          </div>
+        </div>
 
-      </div>
+        <div class="pt-2">
+          <button type="submit" :disabled="loading" class="auth-submit-btn">
+            <svg v-if="loading" class="animate-spin mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+            </svg>
+            {{ loading ? 'Creando cuenta...' : 'Crear Cuenta' }}
+          </button>
+        </div>
+      </form>
+
+      <p class="login-footer-text">
+        ¿Ya tienes cuenta?
+        <router-link to="/" class="login-footer-link">Inicia sesión</router-link>
+      </p>
+
     </div>
-
   </div>
 </template>
 


### PR DESCRIPTION
…jeta glassmorphism centrada

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Resumen de cambios

Este PR rediseña las pantallas de login y registro para implementar un nuevo estilo visual con fondo completo tipo luna y una tarjeta centralizada con efecto glassmorphism.

### Cambios en `src/assets/main.css`

Se han añadido nuevas clases de utilidad para el tema LOGIN:
- `.login-bg`: Establece la imagen de fondo de pantalla completa y centra el contenido
- `.login-overlay`: Aplica un gradiente vertical de profundo a azul
- `.login-card`: Implementa el efecto glassmorphism con blur, bordes, sombras y animación `authFadeUp`

Adicionalmente, se incluyen estilos complementarios para:
- Colores de tipografía y elementos de UI (logo, insignias, títulos y subtítulos)
- Posicionamiento de iconos en campos de entrada
- Inputs temados oscuro con estados hover y focus
- Color de hover para botón de visibilidad de contraseña
- Colores y estilos de los elementos footer

### Cambios en `src/views/Login.vue`

La plantilla del login se ha refactorizado:
- Se elimina el layout de dos paneles (panel de branding + panel de formulario)
- Se reemplaza la estructura externa por un contenedor centralizado sobre un overlay de fondo
- Se remiten los componentes del panel izquierdo (eslogan y estadísticas)
- La tarjeta centralizada ahora integra el logo, insignia, título/subtítulo y formulario utilizando las nuevas clases `login-*`
- La funcionalidad del botón de envío y lógica de carga se mantienen sin cambios
- El enlace de pie de página hacia `/register` persiste con clases actualizadas

### Cambios en `src/views/Register.vue`

El componente se restructura de manera similar:
- Se convierte el layout de dos paneles en un contenedor de fondo único con overlay gradiente
- Se mantiene la reactividad de los campos del formulario (`form.name`, `form.email`, `form.gym_name`, `form.password`, `form.password_confirmation`)
- Se preservan los manejadores (`@submit.prevent="register"`) y la lógica de visibilidad de contraseña (`showPassword`)
- Las clases CSS se actualizan para utilizar los nuevos estilos `login-*`
- El botón de envío y elementos de pie de página se reposicionan dentro de la nueva estructura de tarjeta

**Esfuerzo estimado de revisión:** Medio

<!-- end of auto-generated comment: release notes by coderabbit.ai -->