### PR TITLE
22 eliminar todos iconos y emojis codigo de la app 29 04 2026

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(xargs -I {} grep -L \"lucide-vue-next\" {})",
+      "Bash(npx vue-tsc *)",
+      "Bash(npm run *)"
+    ]
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "axios": "^1.9.0",
         "chart.js": "^4.5.1",
         "dayjs": "^1.11.13",
+        "lucide-vue-next": "^1.0.0",
         "pinia": "^3.0.1",
         "sweetalert2": "^11.22.2",
         "vue": "^3.5.13",
@@ -4260,6 +4261,15 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lucide-vue-next": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/lucide-vue-next/-/lucide-vue-next-1.0.0.tgz",
+      "integrity": "sha512-V6SPvx1IHTj/UY+FrIYWV5faISsPSb8BnWSFDxAtezWKvWc9ZZ40PDrdu1/Qb5vg4lHWr1hs1BAMGVGm6V1Xdg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "vue": ">=3.0.1"
       }
     },
     "node_modules/magic-string": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "0.0.0",
       "dependencies": {
         "@digitalpersona/devices": "^0.2.6",
-        "@lordicon/element": "^2.2.0",
         "animate.css": "^4.1.1",
         "axios": "^1.9.0",
         "chart.js": "^4.5.1",
@@ -1332,21 +1331,6 @@
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
       "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
-      "license": "MIT"
-    },
-    "node_modules/@lordicon/element": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@lordicon/element/-/element-2.2.0.tgz",
-      "integrity": "sha512-HBD8hw2G9E4cZnvrgIrm1USOvprr0pvEB3N0CO6W7j2jMw3EJ+2Z429lo6GGF5RcTLTAUB6B+dr2xXcdkGOplA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lordicon/web": "^1.0.1"
-      }
-    },
-    "node_modules/@lordicon/web": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@lordicon/web/-/web-1.0.1.tgz",
-      "integrity": "sha512-FXC7IkLAjPpCSAZmFLhoKUBLwv6KZq+ifTtp/+GHMEJpEdECUWGEZwWX2pnrpPgD9XJ/k9XKLe4wsW0YRzL2Mg==",
       "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5720,7 +5704,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axios": "^1.9.0",
     "chart.js": "^4.5.1",
     "dayjs": "^1.11.13",
+    "lucide-vue-next": "^1.0.0",
     "pinia": "^3.0.1",
     "sweetalert2": "^11.22.2",
     "vue": "^3.5.13",

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -12,7 +12,7 @@
       <div class="sidebar-logo">
         <span class="sidebar-logo-text font-black">COSMO<span class="text-red-500">GYM</span></span>
         <button class="lg:hidden sidebar-close-btn" @click="sidebarOpen = false" aria-label="Cerrar menú">
-          ✕
+          <X class="w-5 h-5" aria-hidden="true" />
         </button>
       </div>
 
@@ -27,6 +27,9 @@
           :style="{ '--accent': item.color }"
           @click="sidebarOpen = false; adminOpen = false"
         >
+          <div class="sidebar-icon-wrap" aria-hidden="true">
+            <component :is="item.icon" class="w-4 h-4" />
+          </div>
           <span class="sidebar-item-label">{{ item.label }}</span>
         </router-link>
       </nav>
@@ -42,6 +45,7 @@
               :aria-label="isDark ? 'Activar modo claro' : 'Activar modo oscuro'"
             >
               <div class="sidebar-icon-wrap theme-icon-wrap" :class="{ 'is-dark': isDark }">
+                <component :is="isDark ? Sun : Moon" class="w-5 h-5" aria-hidden="true" />
               </div>
               <span class="sidebar-item-label">
                 {{ isDark ? 'Modo claro' : 'Modo oscuro' }}
@@ -58,6 +62,9 @@
               :style="{ '--accent': '#94a3b8' }"
               @click="sidebarOpen = false; adminOpen = false"
             >
+              <div class="sidebar-icon-wrap" aria-hidden="true">
+                <Settings class="w-4 h-4" />
+              </div>
               <span class="sidebar-item-label">Ajustes</span>
             </router-link>
 
@@ -66,6 +73,9 @@
               class="sidebar-item sidebar-item--danger w-full text-left"
               @click="confirmLogout"
             >
+              <div class="sidebar-icon-wrap" aria-hidden="true">
+                <LogOut class="w-4 h-4" />
+              </div>
               <span class="sidebar-item-label text-red-400">Salir</span>
             </button>
           </div>
@@ -77,7 +87,7 @@
             <p class="admin-role">Administrador</p>
             <p class="admin-name">{{ userName }}</p>
           </div>
-          <span class="admin-chevron" :class="{ 'rotate-180': adminOpen }">&#8964;</span>
+          <ChevronDown class="admin-chevron" :class="{ 'rotate-180': adminOpen }" aria-hidden="true" />
         </button>
       </div>
     </aside>
@@ -89,7 +99,7 @@
       <div class="app-topbar lg:hidden">
         <!-- Hamburger solo en móvil -->
         <button class="lg:hidden topbar-ham" @click="sidebarOpen = true" aria-label="Abrir menú">
-          ☰
+          <Menu class="w-5 h-5" aria-hidden="true" />
         </button>
 
         <!-- Logo solo en móvil -->
@@ -111,6 +121,27 @@ import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { useTheme } from '@/composables/useTheme'
 import Swal from 'sweetalert2'
+import {
+  LayoutDashboard,
+  ShoppingCart,
+  Users,
+  CreditCard,
+  Boxes,
+  ClipboardList,
+  BadgeDollarSign,
+  Package,
+  BarChart3,
+  DoorOpen,
+  Store,
+  CalendarCheck2,
+  Sun,
+  Moon,
+  Settings,
+  LogOut,
+  ChevronDown,
+  Menu,
+  X,
+} from 'lucide-vue-next'
 
 const route  = useRoute()
 const router = useRouter()
@@ -132,18 +163,18 @@ const isActive = (to: string) =>
   route.path.toLowerCase() === to.toLowerCase()
 
 const navItems = [
-  { to: '/menu',            label: 'Dashboard',      color: '#6366f1' },
-  { to: '/pos',             label: 'Punto de Venta', color: '#a78bfa' },
-  { to: '/members',         label: 'Clientes',       color: '#34d399' },
-  { to: '/Payments',        label: 'Pagos',          color: '#fbbf24' },
-  { to: '/Products',        label: 'Inventario',     color: '#60a5fa' },
-  { to: '/membershipPlans', label: 'Planes',         color: '#c084fc' },
-  { to: '/Membership',      label: 'Membresías',     color: '#38bdf8' },
-  { to: '/CashBox',         label: 'Caja',           color: '#2dd4bf' },
-  { to: '/statistics',      label: 'Estadísticas',   color: '#fb923c' },
-  { to: '/access-logs',     label: 'Ingresos',       color: '#818cf8' },
-  { to: '/kiosko',          label: 'Kiosco',         color: '#4ade80' },
-  { to: '/subscription',    label: 'Suscripción',    color: '#34d399' },
+  { to: '/menu',            label: 'Dashboard',      color: '#6366f1', icon: LayoutDashboard },
+  { to: '/pos',             label: 'Punto de Venta', color: '#a78bfa', icon: ShoppingCart },
+  { to: '/members',         label: 'Clientes',       color: '#34d399', icon: Users },
+  { to: '/Payments',        label: 'Pagos',          color: '#fbbf24', icon: CreditCard },
+  { to: '/Products',        label: 'Inventario',     color: '#60a5fa', icon: Boxes },
+  { to: '/membershipPlans', label: 'Planes',         color: '#c084fc', icon: ClipboardList },
+  { to: '/Membership',      label: 'Membresías',     color: '#38bdf8', icon: CalendarCheck2 },
+  { to: '/CashBox',         label: 'Caja',           color: '#2dd4bf', icon: BadgeDollarSign },
+  { to: '/statistics',      label: 'Estadísticas',   color: '#fb923c', icon: BarChart3 },
+  { to: '/access-logs',     label: 'Ingresos',       color: '#818cf8', icon: DoorOpen },
+  { to: '/kiosko',          label: 'Kiosco',         color: '#4ade80', icon: Store },
+  { to: '/subscription',    label: 'Suscripción',    color: '#34d399', icon: Package },
 ]
 
 const confirmLogout = async () => {

--- a/src/components/AppLayout.vue
+++ b/src/components/AppLayout.vue
@@ -12,9 +12,7 @@
       <div class="sidebar-logo">
         <span class="sidebar-logo-text font-black">COSMO<span class="text-red-500">GYM</span></span>
         <button class="lg:hidden sidebar-close-btn" @click="sidebarOpen = false" aria-label="Cerrar menú">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          ✕
         </button>
       </div>
 
@@ -44,29 +42,6 @@
               :aria-label="isDark ? 'Activar modo claro' : 'Activar modo oscuro'"
             >
               <div class="sidebar-icon-wrap theme-icon-wrap" :class="{ 'is-dark': isDark }">
-                <Transition name="icon-swap" mode="out-in">
-                  <svg
-                    v-if="isDark"
-                    key="sun"
-                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                    fill="none" stroke="currentColor" stroke-width="2"
-                    stroke-linecap="round" stroke-linejoin="round"
-                    class="theme-svg sun"
-                  >
-                    <circle cx="12" cy="12" r="4"/>
-                    <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41"/>
-                  </svg>
-                  <svg
-                    v-else
-                    key="moon"
-                    xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24"
-                    fill="none" stroke="currentColor" stroke-width="2"
-                    stroke-linecap="round" stroke-linejoin="round"
-                    class="theme-svg moon"
-                  >
-                    <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-                  </svg>
-                </Transition>
               </div>
               <span class="sidebar-item-label">
                 {{ isDark ? 'Modo claro' : 'Modo oscuro' }}
@@ -102,14 +77,7 @@
             <p class="admin-role">Administrador</p>
             <p class="admin-name">{{ userName }}</p>
           </div>
-          <svg
-            class="admin-chevron"
-            :class="{ 'rotate-180': adminOpen }"
-            xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24"
-            stroke-width="2.5" stroke="currentColor"
-          >
-            <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-          </svg>
+          <span class="admin-chevron" :class="{ 'rotate-180': adminOpen }">&#8964;</span>
         </button>
       </div>
     </aside>
@@ -121,9 +89,7 @@
       <div class="app-topbar lg:hidden">
         <!-- Hamburger solo en móvil -->
         <button class="lg:hidden topbar-ham" @click="sidebarOpen = true" aria-label="Abrir menú">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
-          </svg>
+          ☰
         </button>
 
         <!-- Logo solo en móvil -->
@@ -140,6 +106,7 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+
 import { useRoute, useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/useAuthStore'
 import { useTheme } from '@/composables/useTheme'

--- a/src/components/FingerprintEnroll.vue
+++ b/src/components/FingerprintEnroll.vue
@@ -26,10 +26,6 @@
         ? 'bg-[var(--color-overlay-strong)] text-subtle cursor-not-allowed'
         : 'bg-blue-600 hover:bg-blue-700 text-white'"
     >
-      <svg v-if="busy" class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-        <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"/>
-        <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8z"/>
-      </svg>
       {{ busy ? 'Leyendo huella...' : (captured || hasFingerprint ? 'Reemplazar huella' : 'Capturar huella') }}
     </button>
 

--- a/src/components/FingerprintEnroll.vue
+++ b/src/components/FingerprintEnroll.vue
@@ -1,7 +1,8 @@
 
 <template>
   <div class="border border-default-soft rounded-xl p-5 bg-[var(--color-surface-soft)]">
-    <h3 class="text-base font-semibold text-default mb-3">
+    <h3 class="text-base font-semibold text-default mb-3 flex items-center gap-2">
+      <Fingerprint class="w-4 h-4" aria-hidden="true" />
       Huella Dactilar
     </h3>
 
@@ -11,7 +12,7 @@
         class="inline-flex items-center gap-1.5 px-3 py-1 rounded-full text-xs font-medium"
         :class="captured || hasFingerprint ? 'bg-green-100 text-green-700' : 'bg-[var(--color-overlay-strong)] text-muted'"
       >
-        <span class="w-2 h-2 rounded-full" :class="captured || hasFingerprint ? 'bg-green-500' : 'bg-gray-400'"></span>
+        <component :is="captured || hasFingerprint ? Check : Circle" class="w-3 h-3" aria-hidden="true" />
         {{ captured ? 'Huella capturada (se guardará al registrar)' : hasFingerprint ? 'Huella registrada' : 'Sin huella' }}
       </span>
     </div>
@@ -26,15 +27,18 @@
         ? 'bg-[var(--color-overlay-strong)] text-subtle cursor-not-allowed'
         : 'bg-blue-600 hover:bg-blue-700 text-white'"
     >
-      {{ busy ? 'Leyendo huella...' : (captured || hasFingerprint ? 'Reemplazar huella' : 'Capturar huella') }}
+      <Loader2 v-if="busy" class="w-4 h-4 animate-spin" aria-hidden="true" />
+      <Fingerprint v-else class="w-4 h-4" aria-hidden="true" />
+      <span>{{ busy ? 'Leyendo huella...' : (captured || hasFingerprint ? 'Reemplazar huella' : 'Capturar huella') }}</span>
     </button>
 
     <!-- Mensaje de estado -->
     <p v-if="statusMsg" class="mt-3 text-sm text-center text-muted">{{ statusMsg }}</p>
 
     <!-- Resultado -->
-    <div v-if="result" class="mt-3 p-3 rounded-lg text-sm text-center font-medium"
+    <div v-if="result" class="mt-3 p-3 rounded-lg text-sm text-center font-medium flex items-center justify-center gap-2"
       :class="result.success ? 'bg-green-50 text-green-700' : 'bg-red-50 text-red-700'">
+      <component :is="result.success ? CheckCircle2 : XCircle" class="w-4 h-4" aria-hidden="true" />
       {{ result.message }}
     </div>
   </div>
@@ -44,6 +48,7 @@
 import { ref } from 'vue'
 import { useFingerprint } from '@/composables/useFingerprint'
 import { useAuthStore } from '@/stores/useAuthStore'
+import { Fingerprint, Check, Circle, CheckCircle2, XCircle, Loader2 } from 'lucide-vue-next'
 
 const props = defineProps<{
   memberId?: number | null

--- a/src/components/members/MemberAssignModal.vue
+++ b/src/components/members/MemberAssignModal.vue
@@ -1,10 +1,16 @@
 <template>
   <div v-if="show" class="fixed inset-0 flex items-center justify-center z-50 p-4" :style="{ background: 'var(--modal-backdrop)' }">
     <div class="w-full max-w-md p-6 rounded-lg shadow-lg" :style="{ background: 'var(--modal-panel-bg)', border: '1px solid var(--modal-panel-border)' }">
-      <h2 class="text-xl font-bold mb-4">Asignar membresía a {{ member?.name }}</h2>
+      <h2 class="text-xl font-bold mb-4 inline-flex items-center gap-2">
+        <ClipboardList class="w-5 h-5 text-primary-600" aria-hidden="true" />
+        Asignar membresía a {{ member?.name }}
+      </h2>
 
       <form @submit.prevent="asignar">
-        <label class="block mb-1 text-sm">Plan</label>
+        <label class="block mb-1 text-sm inline-flex items-center gap-1.5">
+          <Tag class="w-4 h-4 text-muted" aria-hidden="true" />
+          Plan
+        </label>
         <select v-model="planId" class="field-input" required>
           <option disabled value="">Seleccione un plan</option>
           <option v-for="plan in planes" :key="plan.id" :value="plan.id">
@@ -13,8 +19,13 @@
         </select>
 
         <div class="flex justify-end gap-3 mt-4">
-          <button type="button" @click="$emit('close')" class="btn btn-secondary">Cancelar</button>
-          <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded" :disabled="loading">
+          <button type="button" @click="$emit('close')" class="btn btn-secondary inline-flex items-center gap-2">
+            <X class="w-4 h-4" aria-hidden="true" />
+            Cancelar
+          </button>
+          <button type="submit" class="bg-purple-600 hover:bg-purple-700 text-white px-4 py-2 rounded inline-flex items-center gap-2" :disabled="loading">
+            <Loader2 v-if="loading" class="w-4 h-4 animate-spin" aria-hidden="true" />
+            <Check v-else class="w-4 h-4" aria-hidden="true" />
             {{ loading ? 'Asignando...' : 'Asignar' }}
           </button>
         </div>
@@ -27,6 +38,7 @@
 import { ref } from 'vue'
 import api from '@/axios'
 import Swal from 'sweetalert2'
+import { ClipboardList, Tag, X, Check, Loader2 } from 'lucide-vue-next'
 
 const props = defineProps({
   show: Boolean,

--- a/src/components/members/MemberAssignModal.vue
+++ b/src/components/members/MemberAssignModal.vue
@@ -11,12 +11,12 @@
           <Tag class="w-4 h-4 text-muted" aria-hidden="true" />
           Plan
         </label>
-        <select v-model="planId" class="field-input" required>
-          <option disabled value="">Seleccione un plan</option>
-          <option v-for="plan in planes" :key="plan.id" :value="plan.id">
-            {{ plan.name }}
-          </option>
-        </select>
+        <BaseSelect
+          v-model="planId"
+          placeholder="Seleccione un plan"
+          required
+          :options="planOptions"
+        />
 
         <div class="flex justify-end gap-3 mt-4">
           <button type="button" @click="$emit('close')" class="btn btn-secondary inline-flex items-center gap-2">
@@ -35,10 +35,11 @@
 </template>
 
 <script setup>
-import { ref } from 'vue'
+import { ref, computed } from 'vue'
 import api from '@/axios'
 import Swal from 'sweetalert2'
 import { ClipboardList, Tag, X, Check, Loader2 } from 'lucide-vue-next'
+import { BaseSelect } from '@/components/ui'
 
 const props = defineProps({
   show: Boolean,
@@ -49,6 +50,10 @@ const props = defineProps({
 const emit = defineEmits(['close', 'assigned'])
 const planId = ref("")
 const loading = ref(false)
+
+const planOptions = computed(() =>
+  (props.planes || []).map((p) => ({ value: p.id, label: p.name }))
+)
 
 const asignar = async () => {
   if (!planId.value) return

--- a/src/components/members/MemberDetailModal.vue
+++ b/src/components/members/MemberDetailModal.vue
@@ -12,7 +12,7 @@
 
             <div class="relative flex items-start justify-between gap-3">
               <div class="flex items-center gap-2 text-white/70 text-[11px] font-semibold uppercase tracking-widest">
-                
+                <FileText class="w-4 h-4" aria-hidden="true" />
                 Ficha del cliente
               </div>
               <div class="flex items-center gap-2">
@@ -22,15 +22,20 @@
                   class="btn-ghost-white"
                   @click="close"
                 >
-                  
+                  <Pencil class="w-4 h-4" aria-hidden="true" />
                   Editar
                 </router-link>
-                <a v-if="member?.phone" :href="`https://wa.me/${formatearTelefono(member.phone)}`" target="_blank" class="btn-ghost-white">
-                  
+                <a
+                  v-if="member?.phone"
+                  :href="`https://wa.me/${formatearTelefono(member.phone)}`"
+                  target="_blank"
+                  class="btn-ghost-white"
+                >
+                  <MessageCircle class="w-4 h-4" aria-hidden="true" />
                   WhatsApp
                 </a>
                 <button type="button" class="btn-icon-white" aria-label="Cerrar" @click="close">
-                  ✕
+                  <X class="w-5 h-5" aria-hidden="true" />
                 </button>
               </div>
             </div>
@@ -55,15 +60,15 @@
                   <BaseBadge v-else-if="member" color="gray">Sin plan</BaseBadge>
 
                   <span v-if="member?.identification" class="meta-chip">
-                    
+                    <IdCard class="w-4 h-4" aria-hidden="true" />
                     {{ member.identification }}
                   </span>
                   <span v-if="member?.phone" class="meta-chip">
-                    
+                    <Phone class="w-4 h-4" aria-hidden="true" />
                     {{ member.phone }}
                   </span>
                   <span v-if="member?.email" class="meta-chip">
-                    
+                    <Mail class="w-4 h-4" aria-hidden="true" />
                     {{ member.email }}
                   </span>
                 </div>
@@ -76,7 +81,7 @@
         <div class="detail-body">
           <div v-if="loading" class="py-16 text-center">
             <div class="inline-flex items-center gap-3 text-muted">
-              
+              <Loader2 class="w-5 h-5 animate-spin" aria-hidden="true" />
               Cargando detalle...
             </div>
           </div>
@@ -90,7 +95,7 @@
             <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
               <div class="stat-card">
                 <div class="stat-icon stat-icon-primary">
-                  
+                  <Cake class="w-5 h-5" aria-hidden="true" />
                 </div>
                 <div>
                   <p class="stat-label">Edad</p>
@@ -99,7 +104,7 @@
               </div>
               <div class="stat-card">
                 <div class="stat-icon stat-icon-success">
-                  
+                  <Ruler class="w-5 h-5" aria-hidden="true" />
                 </div>
                 <div>
                   <p class="stat-label">Estatura</p>
@@ -108,7 +113,7 @@
               </div>
               <div class="stat-card">
                 <div class="stat-icon stat-icon-success">
-                  
+                  <Weight class="w-5 h-5" aria-hidden="true" />
                 </div>
                 <div>
                   <p class="stat-label">Peso</p>
@@ -117,7 +122,7 @@
               </div>
               <div class="stat-card">
                 <div class="stat-icon" :class="imcIconCls">
-                  
+                  <Activity class="w-5 h-5" aria-hidden="true" />
                 </div>
                 <div>
                   <p class="stat-label">IMC</p>
@@ -225,7 +230,7 @@
 
                 <div v-else class="detail-card text-center">
                   <div class="w-12 h-12 rounded-full bg-[var(--color-overlay)] flex items-center justify-center mx-auto mb-3">
-                    
+                    <CalendarX2 class="w-6 h-6 text-muted" aria-hidden="true" />
                   </div>
                   <p class="text-sm text-muted">Sin membresía asignada</p>
                 </div>
@@ -244,6 +249,21 @@ import api from "@/axios";
 import dayjs from "dayjs";
 import Swal from "sweetalert2";
 import { BaseBadge } from "@/components/ui";
+import {
+  Activity,
+  CalendarX2,
+  Cake,
+  FileText,
+  IdCard,
+  Loader2,
+  Mail,
+  MessageCircle,
+  Pencil,
+  Phone,
+  Ruler,
+  Weight,
+  X,
+} from 'lucide-vue-next'
 
 const props = defineProps({
   show: Boolean,

--- a/src/components/members/MemberDetailModal.vue
+++ b/src/components/members/MemberDetailModal.vue
@@ -12,9 +12,7 @@
 
             <div class="relative flex items-start justify-between gap-3">
               <div class="flex items-center gap-2 text-white/70 text-[11px] font-semibold uppercase tracking-widest">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
+                
                 Ficha del cliente
               </div>
               <div class="flex items-center gap-2">
@@ -24,21 +22,15 @@
                   class="btn-ghost-white"
                   @click="close"
                 >
-                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
+                  
                   Editar
                 </router-link>
                 <a v-if="member?.phone" :href="`https://wa.me/${formatearTelefono(member.phone)}`" target="_blank" class="btn-ghost-white">
-                  <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20.52 3.48A11.8 11.8 0 0012.04 0C5.52 0 .17 5.35.14 11.87a11.82 11.82 0 001.58 5.94L0 24l6.35-1.67a11.83 11.83 0 005.68 1.45h.01c6.52 0 11.87-5.35 11.9-11.87a11.78 11.78 0 00-3.42-8.43z" />
-                  </svg>
+                  
                   WhatsApp
                 </a>
                 <button type="button" class="btn-icon-white" aria-label="Cerrar" @click="close">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-                  </svg>
+                  ✕
                 </button>
               </div>
             </div>
@@ -63,21 +55,15 @@
                   <BaseBadge v-else-if="member" color="gray">Sin plan</BaseBadge>
 
                   <span v-if="member?.identification" class="meta-chip">
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V4a2 2 0 114 0v2m-4 0a2 2 0 104 0" />
-                    </svg>
+                    
                     {{ member.identification }}
                   </span>
                   <span v-if="member?.phone" class="meta-chip">
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-                    </svg>
+                    
                     {{ member.phone }}
                   </span>
                   <span v-if="member?.email" class="meta-chip">
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                    </svg>
+                    
                     {{ member.email }}
                   </span>
                 </div>
@@ -90,10 +76,7 @@
         <div class="detail-body">
           <div v-if="loading" class="py-16 text-center">
             <div class="inline-flex items-center gap-3 text-muted">
-              <svg class="w-5 h-5 animate-spin text-primary-600" viewBox="0 0 24 24" fill="none">
-                <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-                <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-              </svg>
+              
               Cargando detalle...
             </div>
           </div>
@@ -107,9 +90,7 @@
             <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
               <div class="stat-card">
                 <div class="stat-icon stat-icon-primary">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
+                  
                 </div>
                 <div>
                   <p class="stat-label">Edad</p>
@@ -118,9 +99,7 @@
               </div>
               <div class="stat-card">
                 <div class="stat-icon stat-icon-success">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h8M4 14h8M4 18h16" />
-                  </svg>
+                  
                 </div>
                 <div>
                   <p class="stat-label">Estatura</p>
@@ -129,9 +108,7 @@
               </div>
               <div class="stat-card">
                 <div class="stat-icon stat-icon-success">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M6 3v3M18 3v3M3 9h18M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-                  </svg>
+                  
                 </div>
                 <div>
                   <p class="stat-label">Peso</p>
@@ -140,9 +117,7 @@
               </div>
               <div class="stat-card">
                 <div class="stat-icon" :class="imcIconCls">
-                  <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                  </svg>
+                  
                 </div>
                 <div>
                   <p class="stat-label">IMC</p>
@@ -250,9 +225,7 @@
 
                 <div v-else class="detail-card text-center">
                   <div class="w-12 h-12 rounded-full bg-[var(--color-overlay)] flex items-center justify-center mx-auto mb-3">
-                    <svg class="w-6 h-6 text-subtle" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
-                    </svg>
+                    
                   </div>
                   <p class="text-sm text-muted">Sin membresía asignada</p>
                 </div>

--- a/src/components/members/MemberPaymentModal.vue
+++ b/src/components/members/MemberPaymentModal.vue
@@ -43,10 +43,10 @@
           </button>
           <button
             type="submit"
-            class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded font-bold shadow-lg"
+            class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded font-bold shadow-lg flex items-center gap-2"
             :disabled="processing"
           >
-            {{ processing ? "Procesando..." : "✅ Confirmar Pago" }}
+            {{ processing ? 'Procesando...' : 'Confirmar Pago' }}
           </button>
         </div>
       </form>

--- a/src/components/members/MemberPaymentModal.vue
+++ b/src/components/members/MemberPaymentModal.vue
@@ -38,10 +38,12 @@
             <Banknote class="w-4 h-4 text-muted" aria-hidden="true" />
             Método de Pago
           </label>
-          <select v-model="paymentMethodId" class="field-input" required>
-            <option value="" disabled>Seleccione...</option>
-            <option v-for="m in paymentMethods" :key="m.id" :value="m.id">{{ m.name }}</option>
-          </select>
+          <BaseSelect
+            v-model="paymentMethodId"
+            placeholder="Seleccione..."
+            required
+            :options="paymentMethodOptions"
+          />
         </div>
 
         <div class="flex justify-end gap-3 mt-6">
@@ -70,10 +72,11 @@
 
 // eslint-disable-next-line vue/block-lang
 <script setup>
-import { ref, watch, onMounted } from "vue";
+import { ref, watch, onMounted, computed } from "vue";
 import api from "@/axios";
 import Swal from "sweetalert2";
 import { CreditCard, User, Wallet, Banknote, X, Check, Loader2 } from "lucide-vue-next";
+import { BaseSelect } from "@/components/ui";
 
 const props = defineProps({
   show: Boolean,
@@ -87,6 +90,10 @@ const amount = ref(0);
 const paymentMethodId = ref("");
 const loadingBalance = ref(false);
 const processing = ref(false);
+
+const paymentMethodOptions = computed(() =>
+  paymentMethods.value.map((m) => ({ value: m.id, label: m.name }))
+);
 
 // Cargar métodos de pago una sola vez
 onMounted(async () => {

--- a/src/components/members/MemberPaymentModal.vue
+++ b/src/components/members/MemberPaymentModal.vue
@@ -9,24 +9,35 @@
       :style="{ background: 'var(--modal-panel-bg)', borderLeft: '1px solid var(--modal-panel-border)', borderRight: '1px solid var(--modal-panel-border)', borderBottom: '1px solid var(--modal-panel-border)' }"
     >
       <h2 id="member-payment-modal-title" class="text-xl font-bold mb-2 text-default flex items-center gap-2">
+        <CreditCard class="w-5 h-5 text-emerald-600" aria-hidden="true" />
         Registrar Pago
       </h2>
-      <p class="text-sm text-muted mb-4">
+      <p class="text-sm text-muted mb-4 inline-flex items-center gap-1.5">
+        <User class="w-4 h-4" aria-hidden="true" />
         Cliente: <strong>{{ member?.name }}</strong>
       </p>
 
-      <div v-if="loadingBalance" class="text-center py-4">Buscando deuda...</div>
+      <div v-if="loadingBalance" class="text-center py-4 inline-flex items-center justify-center gap-2 w-full">
+        <Loader2 class="w-4 h-4 animate-spin" aria-hidden="true" />
+        Buscando deuda...
+      </div>
 
       <form v-else @submit.prevent="pagar">
         <div class="mb-4 bg-[var(--color-surface-soft)] p-3 rounded border border-default-soft">
-          <p class="text-sm text-muted">Monto a pagar:</p>
+          <p class="text-sm text-muted inline-flex items-center gap-1.5">
+            <Wallet class="w-4 h-4" aria-hidden="true" />
+            Monto a pagar:
+          </p>
           <p class="text-2xl font-bold text-emerald-600 dark:text-emerald-400">
             {{ formatCurrency(amount) }}
           </p>
         </div>
 
         <div class="mb-4">
-          <label class="block mb-1 text-sm font-medium">Método de Pago</label>
+          <label class="block mb-1 text-sm font-medium inline-flex items-center gap-1.5">
+            <Banknote class="w-4 h-4 text-muted" aria-hidden="true" />
+            Método de Pago
+          </label>
           <select v-model="paymentMethodId" class="field-input" required>
             <option value="" disabled>Seleccione...</option>
             <option v-for="m in paymentMethods" :key="m.id" :value="m.id">{{ m.name }}</option>
@@ -37,8 +48,9 @@
           <button
             type="button"
             @click="$emit('close')"
-            class="btn btn-secondary"
+            class="btn btn-secondary inline-flex items-center gap-2"
           >
+            <X class="w-4 h-4" aria-hidden="true" />
             Cancelar
           </button>
           <button
@@ -46,6 +58,8 @@
             class="bg-green-600 hover:bg-green-700 text-white px-6 py-2 rounded font-bold shadow-lg flex items-center gap-2"
             :disabled="processing"
           >
+            <Loader2 v-if="processing" class="w-4 h-4 animate-spin" aria-hidden="true" />
+            <Check v-else class="w-4 h-4" aria-hidden="true" />
             {{ processing ? 'Procesando...' : 'Confirmar Pago' }}
           </button>
         </div>
@@ -59,6 +73,7 @@
 import { ref, watch, onMounted } from "vue";
 import api from "@/axios";
 import Swal from "sweetalert2";
+import { CreditCard, User, Wallet, Banknote, X, Check, Loader2 } from "lucide-vue-next";
 
 const props = defineProps({
   show: Boolean,

--- a/src/components/members/MemberRegisterModal.vue
+++ b/src/components/members/MemberRegisterModal.vue
@@ -9,12 +9,7 @@
               class="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
               style="background: rgba(99,102,241,0.12); color: #818cf8;"
             >
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24">
-                <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" />
-                <circle cx="9" cy="7" r="4" />
-                <line x1="19" y1="8" x2="19" y2="14" />
-                <line x1="22" y1="11" x2="16" y2="11" />
-              </svg>
+              <UserPlus class="w-5 h-5" aria-hidden="true" />
             </div>
             <div>
               <h1 class="text-xl font-bold text-default tracking-tight leading-tight">
@@ -31,9 +26,7 @@
             aria-label="Cerrar"
             @click="$emit('close')"
           >
-            <svg class="w-5 h-5 text-muted" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-            </svg>
+            <X class="w-5 h-5 text-muted" aria-hidden="true" />
           </button>
         </div>
 
@@ -165,9 +158,7 @@
                   v-if="capturedTemplate"
                   class="mt-3 flex items-center gap-1.5 text-xs font-semibold text-success-700"
                 >
-                  <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4 4L19 7" />
-                  </svg>
+                  <Check class="w-4 h-4" aria-hidden="true" />
                   Huella capturada — se guardará al registrar
                 </p>
               </div>
@@ -202,6 +193,7 @@
 import { ref, reactive, computed } from "vue";
 import api from "@/axios";
 import Swal from "sweetalert2";
+import { Check, UserPlus, X } from 'lucide-vue-next'
 import FingerprintEnroll from "@/components/FingerprintEnroll.vue";
 import { BaseInput, BaseSelect, BaseButton } from "@/components/ui";
 import { SWAL_COLORS } from "@/lib/colors";

--- a/src/components/members/MemberRegisterModal.vue
+++ b/src/components/members/MemberRegisterModal.vue
@@ -171,6 +171,7 @@
           class="px-6 sm:px-8 py-5 border-t border-default-soft bg-[var(--color-surface-soft)] flex items-center justify-end gap-3"
         >
           <BaseButton variant="secondary" @click="$emit('close')">
+            <X class="w-4 h-4 mr-2 inline" aria-hidden="true" />
             Cancelar
           </BaseButton>
           <BaseButton
@@ -181,6 +182,7 @@
             :loading="loading"
             :disabled="loading"
           >
+            <Save class="w-4 h-4 mr-2 inline" aria-hidden="true" />
             Guardar Cliente
           </BaseButton>
         </div>
@@ -193,7 +195,7 @@
 import { ref, reactive, computed } from "vue";
 import api from "@/axios";
 import Swal from "sweetalert2";
-import { Check, UserPlus, X } from 'lucide-vue-next'
+import { Check, UserPlus, X, Save } from 'lucide-vue-next'
 import FingerprintEnroll from "@/components/FingerprintEnroll.vue";
 import { BaseInput, BaseSelect, BaseButton } from "@/components/ui";
 import { SWAL_COLORS } from "@/lib/colors";

--- a/src/components/ui/BaseModal.vue
+++ b/src/components/ui/BaseModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onBeforeUnmount, onMounted, watch } from 'vue'
+import { X } from 'lucide-vue-next'
 
 type Size = 'sm' | 'md' | 'lg' | 'xl'
 
@@ -93,19 +94,7 @@ watch(
             aria-label="Cerrar"
             @click="close"
           >
-            <svg
-              class="w-5 h-5"
-              fill="none"
-              stroke="currentColor"
-              viewBox="0 0 24 24"
-              stroke-width="2"
-            >
-              <path
-                stroke-linecap="round"
-                stroke-linejoin="round"
-                d="M6 18L18 6M6 6l12 12"
-              />
-            </svg>
+            <X class="w-5 h-5" aria-hidden="true" />
           </button>
         </header>
 

--- a/src/components/ui/BaseSelect.vue
+++ b/src/components/ui/BaseSelect.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, useAttrs } from 'vue'
+import { ChevronDown } from 'lucide-vue-next'
 
 defineOptions({ inheritAttrs: false })
 
@@ -84,15 +85,10 @@ const onChange = (event: Event) => {
         <slot />
       </select>
 
-      <svg
+      <ChevronDown
         class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-subtle pointer-events-none"
-        fill="none"
-        stroke="currentColor"
-        viewBox="0 0 24 24"
-        stroke-width="2"
-      >
-        <path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" />
-      </svg>
+        aria-hidden="true"
+      />
     </div>
 
     <p v-if="error" class="text-xs text-red-600 dark:text-red-400">{{ error }}</p>

--- a/src/components/ui/BaseSelect.vue
+++ b/src/components/ui/BaseSelect.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
-import { computed, useAttrs } from 'vue'
-import { ChevronDown } from 'lucide-vue-next'
+import { computed, onBeforeUnmount, onMounted, ref, useAttrs, watch } from 'vue'
+import { ChevronDown, X } from 'lucide-vue-next'
 
 defineOptions({ inheritAttrs: false })
 
@@ -17,11 +17,15 @@ const props = withDefaults(
     error?: string
     hint?: string
     options?: Option[]
+    searchable?: boolean
+    emptyText?: string
   }>(),
   {
     modelValue: '',
     required: false,
     disabled: false,
+    searchable: false,
+    emptyText: 'Sin resultados',
   }
 )
 
@@ -30,15 +34,10 @@ const emit = defineEmits<{
 }>()
 
 const attrs = useAttrs()
-
 const rootClass = computed(() => attrs.class as unknown)
-const selectAttrs = computed(() => {
-  const { class: _c, ...rest } = attrs as Record<string, unknown>
-  return rest
-})
 
 const selectId = computed(
-  () => props.id ?? `select-${Math.random().toString(36).slice(2, 8)}`
+  () => props.id ?? `cosmo-select-${Math.random().toString(36).slice(2, 8)}`
 )
 
 const normalizedOptions = computed(() =>
@@ -47,10 +46,67 @@ const normalizedOptions = computed(() =>
   )
 )
 
-const onChange = (event: Event) => {
-  const target = event.target as HTMLSelectElement
-  emit('update:modelValue', target.value)
+const open = ref(false)
+const searchText = ref('')
+const wrapRef = ref<HTMLElement | null>(null)
+
+const selectedOption = computed(() =>
+  normalizedOptions.value.find((o) => String(o.value) === String(props.modelValue))
+)
+
+const selectedLabel = computed(() => selectedOption.value?.label ?? '')
+
+const filteredOptions = computed(() => {
+  if (!props.searchable || !searchText.value) return normalizedOptions.value
+  const lower = searchText.value.toLowerCase()
+  return normalizedOptions.value.filter((o) => o.label.toLowerCase().includes(lower))
+})
+
+watch(
+  () => props.modelValue,
+  () => {
+    if (props.searchable) {
+      searchText.value = selectedLabel.value
+    }
+  },
+  { immediate: true }
+)
+
+const toggle = () => {
+  if (props.disabled) return
+  open.value = !open.value
 }
+
+const selectOption = (opt: { value: string | number; label: string }) => {
+  emit('update:modelValue', opt.value)
+  if (props.searchable) searchText.value = opt.label
+  open.value = false
+}
+
+const clearSelection = () => {
+  emit('update:modelValue', '')
+  searchText.value = ''
+  open.value = false
+}
+
+const onSearchInput = () => {
+  open.value = true
+  if (props.modelValue !== '' && props.modelValue !== null) {
+    emit('update:modelValue', '')
+  }
+}
+
+const onClickOutside = (e: MouseEvent) => {
+  if (wrapRef.value && !wrapRef.value.contains(e.target as Node)) {
+    open.value = false
+    if (props.searchable) {
+      searchText.value = selectedLabel.value
+    }
+  }
+}
+
+onMounted(() => document.addEventListener('click', onClickOutside))
+onBeforeUnmount(() => document.removeEventListener('click', onClickOutside))
 </script>
 
 <template>
@@ -60,21 +116,85 @@ const onChange = (event: Event) => {
       <span v-if="required" class="text-red-500" aria-hidden="true">*</span>
     </label>
 
-    <div class="relative">
-      <select
+    <div ref="wrapRef" class="cosmo-select-wrap relative">
+      <input
+        v-if="searchable"
         :id="selectId"
-        :value="modelValue"
-        :required="required"
+        v-model="searchText"
+        type="text"
+        :placeholder="placeholder ?? 'Buscar...'"
+        :disabled="disabled"
+        autocomplete="off"
+        :class="[
+          'cosmo-select-input w-full',
+          error && 'cosmo-select-input--error',
+          disabled && 'cosmo-select-input--disabled',
+        ]"
+        @focus="open = true"
+        @input="onSearchInput"
+      />
+      <button
+        v-else
+        :id="selectId"
+        type="button"
         :disabled="disabled"
         :class="[
-          'field-input appearance-none pr-10 cursor-pointer',
-          error && 'border-red-400 focus:border-red-500',
-          disabled && 'opacity-60 cursor-not-allowed',
+          'cosmo-select-input cosmo-select-button w-full text-left',
+          error && 'cosmo-select-input--error',
+          disabled && 'cosmo-select-input--disabled',
         ]"
-        v-bind="selectAttrs"
-        @change="onChange"
+        @click="toggle"
       >
-        <option v-if="placeholder" disabled value="">{{ placeholder }}</option>
+        <span v-if="selectedLabel">{{ selectedLabel }}</span>
+        <span v-else class="cosmo-select-placeholder">
+          {{ placeholder ?? 'Seleccionar...' }}
+        </span>
+      </button>
+
+      <button
+        v-if="searchable && searchText && !disabled"
+        type="button"
+        class="cosmo-select-clear"
+        title="Borrar selección"
+        aria-label="Borrar selección"
+        @click.stop="clearSelection"
+      >
+        <X class="w-4 h-4" aria-hidden="true" />
+      </button>
+      <ChevronDown
+        v-else
+        class="cosmo-select-chevron"
+        :class="{ 'cosmo-select-chevron--open': open }"
+        aria-hidden="true"
+      />
+
+      <ul v-if="open && !disabled" class="cosmo-select-list">
+        <li v-if="filteredOptions.length === 0" class="cosmo-select-empty">
+          {{ emptyText }}
+        </li>
+        <li
+          v-for="opt in filteredOptions"
+          :key="opt.value"
+          :class="[
+            'cosmo-select-item',
+            String(opt.value) === String(modelValue) && 'cosmo-select-item--active',
+          ]"
+          @click="selectOption(opt)"
+        >
+          {{ opt.label }}
+        </li>
+      </ul>
+
+      <select
+        v-if="required"
+        tabindex="-1"
+        aria-hidden="true"
+        class="cosmo-select-hidden"
+        :value="modelValue ?? ''"
+        :required="required"
+        @focus="(e) => ((e.target as HTMLSelectElement).blur())"
+      >
+        <option value="" />
         <option
           v-for="opt in normalizedOptions"
           :key="opt.value"
@@ -82,16 +202,202 @@ const onChange = (event: Event) => {
         >
           {{ opt.label }}
         </option>
-        <slot />
       </select>
-
-      <ChevronDown
-        class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-subtle pointer-events-none"
-        aria-hidden="true"
-      />
     </div>
 
     <p v-if="error" class="text-xs text-red-600 dark:text-red-400">{{ error }}</p>
     <p v-else-if="hint" class="text-xs text-subtle">{{ hint }}</p>
   </div>
 </template>
+
+<style scoped>
+.cosmo-select-wrap {
+  position: relative;
+}
+
+.cosmo-select-input {
+  height: 3rem;
+  font-weight: 600;
+  border: 1.5px solid rgba(59, 130, 246, 0.3);
+  background: rgba(59, 130, 246, 0.04);
+  color: var(--color-text);
+  border-radius: 0.75rem;
+  transition: all 0.25s ease;
+  font-size: 0.95rem;
+  padding: 0 2.5rem 0 1rem;
+  outline: none;
+  display: block;
+}
+.cosmo-select-input::placeholder {
+  color: var(--color-text);
+  opacity: 0.7;
+}
+.cosmo-select-input:hover:not(:disabled) {
+  background: rgba(59, 130, 246, 0.08);
+  border-color: rgba(59, 130, 246, 0.5);
+}
+.cosmo-select-input:focus {
+  border-color: #3b82f6;
+  background: var(--color-surface);
+  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
+}
+
+.cosmo-select-button {
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+}
+.cosmo-select-placeholder {
+  color: var(--color-text);
+  opacity: 0.6;
+  font-weight: 500;
+}
+
+.cosmo-select-input--error {
+  border-color: rgba(244, 63, 94, 0.6) !important;
+}
+.cosmo-select-input--error:focus {
+  border-color: #f43f5e !important;
+  box-shadow: 0 0 0 4px rgba(244, 63, 94, 0.15) !important;
+}
+
+.cosmo-select-input--disabled,
+.cosmo-select-input:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+:global(.dark) .cosmo-select-input {
+  background: rgba(96, 165, 250, 0.08);
+  border-color: rgba(96, 165, 250, 0.25);
+  color: #93c5fd;
+}
+:global(.dark) .cosmo-select-input::placeholder {
+  color: rgba(147, 197, 253, 0.7);
+}
+:global(.dark) .cosmo-select-input:hover:not(:disabled) {
+  background: rgba(96, 165, 250, 0.12);
+  border-color: rgba(96, 165, 250, 0.4);
+}
+:global(.dark) .cosmo-select-input:focus {
+  background: var(--color-surface);
+  border-color: #60a5fa;
+  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.2);
+}
+:global(.dark) .cosmo-select-placeholder {
+  color: rgba(147, 197, 253, 0.7);
+  opacity: 1;
+}
+
+.cosmo-select-chevron {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.25rem;
+  height: 1.25rem;
+  color: rgba(156, 163, 175, 0.9);
+  pointer-events: none;
+  transition: transform 0.2s ease;
+}
+.cosmo-select-chevron--open {
+  transform: translateY(-50%) rotate(180deg);
+}
+
+.cosmo-select-clear {
+  position: absolute;
+  right: 0.75rem;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1.25rem;
+  height: 1.25rem;
+  color: rgba(156, 163, 175, 0.9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  z-index: 10;
+  transition: color 0.15s ease;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+.cosmo-select-clear:hover {
+  color: #ef4444;
+}
+
+.cosmo-select-list {
+  position: absolute;
+  z-index: 50;
+  width: 100%;
+  margin-top: 0.25rem;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px -5px rgba(0, 0, 0, 0.15), 0 6px 10px -5px rgba(0, 0, 0, 0.08);
+  max-height: 15rem;
+  overflow-y: auto;
+  list-style: none;
+  padding: 0;
+}
+:global(.dark) .cosmo-select-list {
+  background: #1f2937;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.cosmo-select-empty {
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: var(--color-text-muted);
+}
+
+.cosmo-select-item {
+  padding: 0.625rem 1rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+  color: var(--color-text-soft);
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+.cosmo-select-item:hover {
+  background: rgba(59, 130, 246, 0.08);
+  color: #2563eb;
+}
+:global(.dark) .cosmo-select-item {
+  color: #e5e7eb;
+}
+:global(.dark) .cosmo-select-item:hover {
+  background: rgba(59, 130, 246, 0.18);
+  color: #93c5fd;
+}
+
+.cosmo-select-item--active {
+  background: rgba(59, 130, 246, 0.12);
+  color: #2563eb;
+  font-weight: 600;
+}
+:global(.dark) .cosmo-select-item--active {
+  background: rgba(59, 130, 246, 0.25);
+  color: #93c5fd;
+}
+
+.cosmo-select-list::-webkit-scrollbar {
+  width: 6px;
+}
+.cosmo-select-list::-webkit-scrollbar-track {
+  background: transparent;
+}
+.cosmo-select-list::-webkit-scrollbar-thumb {
+  background: rgba(156, 163, 175, 0.5);
+  border-radius: 4px;
+}
+
+.cosmo-select-hidden {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  opacity: 0;
+  pointer-events: none;
+  z-index: -1;
+}
+</style>

--- a/src/views/AccessLogs.vue
+++ b/src/views/AccessLogs.vue
@@ -3,16 +3,22 @@
     <div class="max-w-5xl mx-auto">
       <BaseCard title="Registro de Ingresos" subtitle="Historial de accesos al gimnasio" class="space-y-4">
         <template #actions>
-          <router-link :to="{ name: 'Menu' }" class="btn btn-secondary">Volver</router-link>
+          <router-link :to="{ name: 'Menu' }" class="btn btn-secondary inline-flex items-center justify-center gap-2">
+            <ArrowLeft class="w-4 h-4" aria-hidden="true" />
+            <span>Volver</span>
+          </router-link>
         </template>
 
         <div class="flex flex-col sm:flex-row gap-3">
-          <BaseInput
-            v-model="search"
-            type="text"
-            placeholder="Buscar por nombre o identificación..."
-            class="flex-1"
-          />
+          <div class="relative flex-1">
+            <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none z-10" aria-hidden="true" />
+            <BaseInput
+              v-model="search"
+              type="text"
+              placeholder="Buscar por nombre o identificación..."
+              class="pl-10"
+            />
+          </div>
           <BaseSelect
             v-model="filterMethod"
             :options="methodOptions"
@@ -46,6 +52,7 @@
                 <td class="text-muted">{{ log.member?.identification ?? '—' }}</td>
                 <td>
                   <BaseBadge :color="log.method === 'huella' ? 'violet' : 'blue'">
+                    <component :is="log.method === 'huella' ? Fingerprint : IdCard" class="w-3 h-3" aria-hidden="true" />
                     {{ log.method === 'huella' ? 'Huella' : 'Cédula' }}
                   </BaseBadge>
                 </td>
@@ -54,6 +61,7 @@
                     :color="log.status === 'permitido' ? 'green' : 'red'"
                     dot
                   >
+                    <component :is="log.status === 'permitido' ? Check : X" class="w-3 h-3" aria-hidden="true" />
                     {{ log.status === 'permitido' ? 'Permitido' : 'Denegado' }}
                   </BaseBadge>
                 </td>
@@ -77,6 +85,7 @@
               :disabled="meta.current_page === 1"
               @click="changePage(meta.current_page - 1)"
             >
+              <ChevronLeft class="w-4 h-4" aria-hidden="true" />
               Anterior
             </BaseButton>
             <BaseButton
@@ -86,6 +95,7 @@
               @click="changePage(meta.current_page + 1)"
             >
               Siguiente
+              <ChevronRight class="w-4 h-4" aria-hidden="true" />
             </BaseButton>
           </div>
         </div>
@@ -98,6 +108,16 @@
 import { ref, computed, onMounted } from 'vue'
 import api from '@/axios'
 import { BaseSelect, BaseInput, BaseButton, BaseCard, BaseBadge } from '@/components/ui'
+import {
+  ArrowLeft,
+  Search,
+  Fingerprint,
+  IdCard,
+  Check,
+  X,
+  ChevronLeft,
+  ChevronRight,
+} from 'lucide-vue-next'
 
 const methodOptions = [
   { value: '', label: 'Todos los métodos' },

--- a/src/views/CashBox.vue
+++ b/src/views/CashBox.vue
@@ -2,13 +2,16 @@
   <div class="page-layout">
     <BaseCard title="Caja Diaria" subtitle="Control de apertura y cierre" class="space-y-6">
       <template #actions>
-        <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none">
-          Inicio
+        <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+          <Home class="w-4 h-4" aria-hidden="true" />
+          <span>Inicio</span>
         </router-link>
         <BaseButton variant="danger-solid" class="flex-1 sm:flex-none" @click="abrirModalGasto">
+          <ArrowDownToLine class="w-4 h-4" aria-hidden="true" />
           Registrar gasto
         </BaseButton>
         <BaseButton variant="dark" class="flex-1 sm:flex-none" @click="confirmarCierre">
+          <Lock class="w-4 h-4" aria-hidden="true" />
           Cerrar caja
         </BaseButton>
       </template>
@@ -21,31 +24,44 @@
           class="p-4 rounded-xl border shadow-sm"
           style="background: var(--color-surface-soft); border-color: var(--color-border);"
         >
-          <h3 class="text-sm font-semibold mb-3 uppercase tracking-wide" style="color: var(--color-text-muted);">
+          <h3 class="text-sm font-semibold mb-3 uppercase tracking-wide flex items-center gap-2" style="color: var(--color-text-muted);">
+            <Calendar class="w-4 h-4" aria-hidden="true" />
             Resumen Hoy ({{ todayCashbox.date }})
           </h3>
 
           <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 text-sm">
             <div class="bg-[var(--color-surface)] p-3 rounded-lg shadow-sm border border-default-soft">
-              <p class="text-muted text-xs">Apertura</p>
+              <p class="text-muted text-xs flex items-center gap-1">
+                <Wallet class="w-3 h-3" aria-hidden="true" />
+                Apertura
+              </p>
               <p class="text-lg font-semibold text-default">
                 {{ formatCurrency(todayCashbox.opening_balance) }}
               </p>
             </div>
             <div class="bg-[var(--color-surface)] p-3 rounded-lg shadow-sm border border-default-soft">
-              <p class="text-emerald-600 dark:text-emerald-400 text-xs">Ingresos</p>
+              <p class="text-emerald-600 dark:text-emerald-400 text-xs flex items-center gap-1">
+                <ArrowUpFromLine class="w-3 h-3" aria-hidden="true" />
+                Ingresos
+              </p>
               <p class="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
                 {{ formatCurrency(todayCashbox.total_income) }}
               </p>
             </div>
             <div class="bg-[var(--color-surface)] p-3 rounded-lg shadow-sm border border-default-soft">
-              <p class="text-red-500 dark:text-red-400 text-xs">Gastos</p>
+              <p class="text-red-500 dark:text-red-400 text-xs flex items-center gap-1">
+                <ArrowDownToLine class="w-3 h-3" aria-hidden="true" />
+                Gastos
+              </p>
               <p class="text-lg font-semibold text-red-500 dark:text-red-400">
                 {{ formatCurrency(todayCashbox.total_expense) }}
               </p>
             </div>
             <div class="bg-blue-600 p-3 rounded-lg shadow text-white">
-              <p class="text-blue-100 text-xs">Cierre</p>
+              <p class="text-blue-100 text-xs flex items-center gap-1">
+                <BadgeDollarSign class="w-3 h-3" aria-hidden="true" />
+                Cierre
+              </p>
               <p class="text-lg font-semibold">
                 {{ formatCurrency(todayCashbox.closing_balance) }}
               </p>
@@ -70,7 +86,10 @@
               required
               class="flex-1"
             />
-            <BaseButton variant="primary" type="submit">Abrir</BaseButton>
+            <BaseButton variant="primary" type="submit">
+              <Unlock class="w-4 h-4" aria-hidden="true" />
+              Abrir
+            </BaseButton>
           </form>
         </div>
 
@@ -133,9 +152,11 @@
 
       <template #footer>
         <BaseButton variant="secondary" @click="showExpenseModal = false">
+          <X class="w-4 h-4" aria-hidden="true" />
           Cancelar
         </BaseButton>
         <BaseButton variant="danger-solid" type="submit" form="expense-form">
+          <Check class="w-4 h-4" aria-hidden="true" />
           Guardar
         </BaseButton>
       </template>
@@ -151,6 +172,18 @@ import Swal from "sweetalert2";
 import { useRouter } from "vue-router";
 import { BaseButton, BaseInput, BaseCard, BaseModal } from "@/components/ui";
 import { SWAL_COLORS } from "@/lib/colors";
+import {
+  Home,
+  Lock,
+  Unlock,
+  Calendar,
+  Wallet,
+  BadgeDollarSign,
+  ArrowDownToLine,
+  ArrowUpFromLine,
+  X,
+  Check,
+} from "lucide-vue-next";
 const router = useRouter();
 const cashboxes = ref([]);
 const todayCashbox = ref(null);

--- a/src/views/Configuracion.vue
+++ b/src/views/Configuracion.vue
@@ -3,29 +3,40 @@
     <div class="max-w-3xl mx-auto">
       <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center mb-8 gap-4">
         <div class="flex items-center gap-3">
+          <Settings class="w-8 h-8 text-default" aria-hidden="true" />
           <div>
             <h1 class="text-2xl sm:text-3xl font-bold text-default tracking-tight">Configuración</h1>
             <p class="text-sm text-subtle mt-0.5">Personalización del gimnasio</p>
           </div>
         </div>
-        <router-link to="/Menu" class="btn btn-dark">Inicio</router-link>
+        <router-link to="/Menu" class="btn btn-dark inline-flex items-center justify-center gap-2">
+          <Home class="w-4 h-4" aria-hidden="true" />
+          <span>Inicio</span>
+        </router-link>
       </div>
 
       <div class="bg-[var(--color-surface)] rounded-2xl shadow-xl p-6 sm:p-8 text-default animate-fade-in-up border border-default-soft">
         <div class="border-b border-default-soft pb-4 mb-6">
-          <h2 class="text-xl font-bold" style="color: var(--color-text);">Personalización de Bienvenida</h2>
+          <h2 class="text-xl font-bold flex items-center gap-2" style="color: var(--color-text);">
+            <Mail class="w-5 h-5" aria-hidden="true" />
+            Personalización de Bienvenida
+          </h2>
           <p class="text-sm text-muted">
             Esta información se enviará automáticamente por correo a los nuevos clientes.
           </p>
         </div>
 
         <div v-if="loading" class="text-center py-10">
-          <p class="text-blue-600 font-bold animate-pulse">Cargando configuración...</p>
+          <p class="text-blue-600 font-bold animate-pulse flex items-center justify-center gap-2">
+            <Loader2 class="w-5 h-5 animate-spin" aria-hidden="true" />
+            Cargando configuración...
+          </p>
         </div>
 
         <form v-else @submit.prevent="guardarConfiguracion" class="space-y-6">
           <div>
-            <label class="block text-sm font-bold text-muted mb-2 uppercase tracking-wide">
+            <label class="block text-sm font-bold text-muted mb-2 uppercase tracking-wide flex items-center gap-2">
+              <Clock class="w-4 h-4" aria-hidden="true" />
               Horarios de Atención
             </label>
             <div class="relative">
@@ -41,7 +52,8 @@
           </div>
 
           <div>
-            <label class="block text-sm font-bold text-muted mb-2 uppercase tracking-wide">
+            <label class="block text-sm font-bold text-muted mb-2 uppercase tracking-wide flex items-center gap-2">
+              <FileText class="w-4 h-4" aria-hidden="true" />
               Normas y Políticas
             </label>
             <div class="relative">
@@ -59,6 +71,7 @@
             <label
               class="block text-sm font-bold mb-2 uppercase tracking-wide flex items-center gap-2 text-emerald-600 dark:text-emerald-400"
             >
+              <MessageCircle class="w-4 h-4" aria-hidden="true" />
               Enlace Grupo WhatsApp
             </label>
             <input
@@ -76,6 +89,7 @@
           <!-- SECCIÓN CÓDIGO QR -->
           <div class="border-t pt-6" v-if="qrImageUrl">
             <h3 class="text-lg font-bold text-default mb-2 flex items-center gap-2">
+              <QrCode class="w-5 h-5" aria-hidden="true" />
               Código QR de Registro
             </h3>
             <p class="text-sm text-muted mb-4">
@@ -99,19 +113,22 @@
                   @click="descargarImagen"
                   class="btn btn-dark flex items-center justify-center gap-2 text-sm"
                 >
+                  <Download class="w-4 h-4" aria-hidden="true" />
                   Descargar Imagen
                 </button>
                 <button
                   @click="imprimirQR"
                   class="btn btn-primary flex items-center justify-center gap-2 text-sm"
                 >
+                  <Printer class="w-4 h-4" aria-hidden="true" />
                   Imprimir / Guardar PDF
                 </button>
                 <a
                   :href="registrationUrl"
                   target="_blank"
-                  class="text-blue-600 underline text-sm text-center mt-2"
+                  class="text-blue-600 underline text-sm text-center mt-2 inline-flex items-center justify-center gap-1"
                 >
+                  <ExternalLink class="w-3 h-3" aria-hidden="true" />
                   Probar enlace de registro
                 </a>
               </div>
@@ -124,7 +141,9 @@
               class="btn btn-primary px-8 py-3 text-lg shadow-lg hover:shadow-xl transition transform active:scale-95 flex items-center gap-2"
               :disabled="guardando"
             >
-              {{ guardando ? "Guardando..." : "Guardar Cambios" }}
+              <Loader2 v-if="guardando" class="w-5 h-5 animate-spin" aria-hidden="true" />
+              <Save v-else class="w-5 h-5" aria-hidden="true" />
+              <span>{{ guardando ? "Guardando..." : "Guardar Cambios" }}</span>
             </button>
           </div>
         </form>
@@ -138,6 +157,20 @@ import { ref, onMounted } from "vue";
 
 import api from "@/axios";
 import Swal from "sweetalert2";
+import {
+  Settings,
+  Home,
+  Mail,
+  Clock,
+  FileText,
+  MessageCircle,
+  QrCode,
+  Download,
+  Printer,
+  ExternalLink,
+  Save,
+  Loader2,
+} from "lucide-vue-next";
 
 const loading = ref(true);
 const guardando = ref(false);

--- a/src/views/Configuracion.vue
+++ b/src/views/Configuracion.vue
@@ -26,7 +26,7 @@
         <form v-else @submit.prevent="guardarConfiguracion" class="space-y-6">
           <div>
             <label class="block text-sm font-bold text-muted mb-2 uppercase tracking-wide">
-              🕒 Horarios de Atención
+              Horarios de Atención
             </label>
             <div class="relative">
               <textarea
@@ -35,14 +35,14 @@
                 class="field-input rounded-xl p-3"
                 placeholder="Ej: Lunes a Viernes: 6:00 AM - 10:00 PM&#10;Sábados: 8:00 AM - 4:00 PM"
               ></textarea>
-              <div class="absolute top-3 right-3 text-xl opacity-50">📅</div>
+
             </div>
             <p class="text-xs text-muted mt-1">Aparecerá en el correo de bienvenida.</p>
           </div>
 
           <div>
             <label class="block text-sm font-bold text-muted mb-2 uppercase tracking-wide">
-              📜 Normas y Políticas
+              Normas y Políticas
             </label>
             <div class="relative">
               <textarea
@@ -51,7 +51,7 @@
                 class="field-input rounded-xl p-3"
                 placeholder="Ej: 1. Uso obligatorio de toalla.&#10;2. Ordenar las pesas al terminar.&#10;3. No ingresar alimentos."
               ></textarea>
-              <div class="absolute top-3 right-3 text-xl opacity-50">⚖️</div>
+
             </div>
           </div>
 
@@ -59,7 +59,7 @@
             <label
               class="block text-sm font-bold mb-2 uppercase tracking-wide flex items-center gap-2 text-emerald-600 dark:text-emerald-400"
             >
-              <span class="text-xl">📲</span> Enlace Grupo WhatsApp
+              Enlace Grupo WhatsApp
             </label>
             <input
               v-model="form.url_grupo_whatsapp"
@@ -76,7 +76,7 @@
           <!-- SECCIÓN CÓDIGO QR -->
           <div class="border-t pt-6" v-if="qrImageUrl">
             <h3 class="text-lg font-bold text-default mb-2 flex items-center gap-2">
-              🏁 Código QR de Registro
+              Código QR de Registro
             </h3>
             <p class="text-sm text-muted mb-4">
               Imprime este código y colócalo en la recepción. Los clientes podrán escanearlo para
@@ -99,13 +99,13 @@
                   @click="descargarImagen"
                   class="btn btn-dark flex items-center justify-center gap-2 text-sm"
                 >
-                  📥 Descargar Imagen
+                  Descargar Imagen
                 </button>
                 <button
                   @click="imprimirQR"
                   class="btn btn-primary flex items-center justify-center gap-2 text-sm"
                 >
-                  🖨️ Imprimir / Guardar PDF
+                  Imprimir / Guardar PDF
                 </button>
                 <a
                   :href="registrationUrl"
@@ -124,8 +124,7 @@
               class="btn btn-primary px-8 py-3 text-lg shadow-lg hover:shadow-xl transition transform active:scale-95 flex items-center gap-2"
               :disabled="guardando"
             >
-              <span v-if="guardando" class="animate-spin">🔄</span>
-              {{ guardando ? "Guardando..." : "💾 Guardar Cambios" }}
+              {{ guardando ? "Guardando..." : "Guardar Cambios" }}
             </button>
           </div>
         </form>
@@ -136,6 +135,7 @@
 
 <script setup>
 import { ref, onMounted } from "vue";
+
 import api from "@/axios";
 import Swal from "sweetalert2";
 

--- a/src/views/FingerprintKiosk.vue
+++ b/src/views/FingerprintKiosk.vue
@@ -3,7 +3,10 @@
 
     <!-- Logo / Nombre -->
     <div class="mb-10 text-center">
-      <h1 class="text-3xl font-bold text-white tracking-wide">Control de Acceso</h1>
+      <h1 class="text-3xl font-bold text-white tracking-wide flex items-center justify-center gap-2">
+        <DoorOpen class="w-8 h-8" aria-hidden="true" />
+        Control de Acceso
+      </h1>
       <p class="text-subtle mt-1 text-sm">Coloca tu dedo en el lector para ingresar</p>
     </div>
 
@@ -14,7 +17,9 @@
       <div
         class="w-28 h-28 rounded-full flex items-center justify-center transition-all duration-500"
         :class="iconClass"
-      ></div>
+      >
+        <component :is="stateIcon" class="w-14 h-14" aria-hidden="true" />
+      </div>
 
       <!-- Mensaje de estado -->
       <p class="text-center text-lg font-medium" :class="textClass">
@@ -40,15 +45,16 @@
       <button
         v-if="!scanning && state !== 'expired'"
         @click="manualRetry"
-        class="w-full mt-2 py-3 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-700 text-white transition-colors"
+        class="w-full mt-2 py-3 rounded-xl text-sm font-semibold bg-blue-600 hover:bg-blue-700 text-white transition-colors inline-flex items-center justify-center gap-2"
       >
-        {{ state === 'idle' && !member ? 'Escanear huella' : 'Escanear de nuevo' }}
+        <Fingerprint class="w-4 h-4" aria-hidden="true" />
+        <span>{{ state === 'idle' && !member ? 'Escanear huella' : 'Escanear de nuevo' }}</span>
       </button>
     </div>
 
     <!-- Indicador de conexión con el bridge -->
     <p class="mt-6 text-xs flex items-center gap-1.5" :class="connected ? 'text-green-400' : 'text-red-400'">
-      <span class="w-2 h-2 rounded-full" :class="connected ? 'bg-green-400' : 'bg-red-400'"></span>
+      <component :is="connected ? Wifi : WifiOff" class="w-3 h-3" aria-hidden="true" />
       {{ connected ? 'Lector conectado' : 'Lector desconectado' }}
     </p>
   </div>
@@ -58,6 +64,15 @@
 import { ref, computed, onMounted } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useFingerprint } from '@/composables/useFingerprint'
+import {
+  DoorOpen,
+  Fingerprint,
+  Check,
+  X,
+  AlertTriangle,
+  Wifi,
+  WifiOff,
+} from 'lucide-vue-next'
 
 const route  = useRoute()
 const router = useRouter()
@@ -104,6 +119,13 @@ const textClass = computed(() => ({
   'text-red-400':   state.value === 'expired' || state.value === 'unknown',
   'text-subtle':  state.value === 'idle',
 }))
+
+const stateIcon = computed(() => {
+  if (state.value === 'success')  return Check
+  if (state.value === 'expired')  return AlertTriangle
+  if (state.value === 'unknown')  return X
+  return Fingerprint
+})
 
 const displayMessage = computed(() => {
   if (state.value === 'scanning') return statusMsg.value || 'Leyendo huella...'

--- a/src/views/InventoryLog.vue
+++ b/src/views/InventoryLog.vue
@@ -6,7 +6,10 @@
           <h1 class="page-title">Movimientos de Inventario</h1>
           <p class="page-subtitle">Historial de ventas y compras</p>
         </div>
-        <router-link to="/Products" class="btn btn-dark">Inventario</router-link>
+        <router-link to="/Products" class="btn btn-dark inline-flex items-center justify-center gap-2">
+          <Boxes class="w-4 h-4" aria-hidden="true" />
+          <span>Inventario</span>
+        </router-link>
       </header>
 
       <div
@@ -17,7 +20,7 @@
           type="button"
           role="tab"
           :aria-selected="tab === 'ventas'"
-          class="px-6 py-2 rounded-lg font-semibold transition text-sm sm:text-base"
+          class="px-6 py-2 rounded-lg font-semibold transition text-sm sm:text-base inline-flex items-center gap-2"
           :class="
             tab === 'ventas'
               ? 'bg-blue-600 text-white shadow'
@@ -25,13 +28,14 @@
           "
           @click="tab = 'ventas'"
         >
+          <ShoppingCart class="w-4 h-4" aria-hidden="true" />
           Reporte de Ventas
         </button>
         <button
           type="button"
           role="tab"
           :aria-selected="tab === 'compras'"
-          class="px-6 py-2 rounded-lg font-semibold transition text-sm sm:text-base"
+          class="px-6 py-2 rounded-lg font-semibold transition text-sm sm:text-base inline-flex items-center gap-2"
           :class="
             tab === 'compras'
               ? 'bg-emerald-600 text-white shadow'
@@ -39,6 +43,7 @@
           "
           @click="tab = 'compras'"
         >
+          <Truck class="w-4 h-4" aria-hidden="true" />
           Compras a Proveedores
         </button>
       </div>
@@ -48,11 +53,15 @@
         class="bg-[var(--color-surface)] rounded-2xl shadow-card p-4 sm:p-6 text-default animate-fade-in space-y-4"
       >
         <div class="flex justify-between items-center gap-3 flex-wrap">
-          <h2 class="text-xl font-semibold" style="color: var(--color-text);">Historial de Ventas</h2>
+          <h2 class="text-xl font-semibold flex items-center gap-2" style="color: var(--color-text);">
+            <Receipt class="w-5 h-5" aria-hidden="true" />
+            Historial de Ventas
+          </h2>
           <div
-            class="text-sm px-3 py-1 rounded-lg border"
+            class="text-sm px-3 py-1 rounded-lg border inline-flex items-center gap-1"
             style="color: var(--color-text-muted); background: var(--color-surface-soft); border-color: var(--color-border);"
           >
+            <DollarSign class="w-3 h-3" aria-hidden="true" />
             Total Vendido:
             <span class="font-semibold text-emerald-500">
               {{ formatCurrency(totalVentas) }}
@@ -110,6 +119,7 @@
               :disabled="currentPageVentas === 1"
               @click="currentPageVentas--"
             >
+              <ChevronLeft class="w-4 h-4" aria-hidden="true" />
               Anterior
             </BaseButton>
             <BaseButton
@@ -119,6 +129,7 @@
               @click="currentPageVentas++"
             >
               Siguiente
+              <ChevronRight class="w-4 h-4" aria-hidden="true" />
             </BaseButton>
           </div>
         </div>
@@ -129,8 +140,12 @@
         class="bg-[var(--color-surface)] rounded-2xl shadow-card p-4 sm:p-6 text-default animate-fade-in space-y-4"
       >
         <div class="flex justify-between items-center gap-3 flex-wrap">
-          <h2 class="text-xl font-semibold" style="color: var(--color-text);">Historial de Compras</h2>
+          <h2 class="text-xl font-semibold flex items-center gap-2" style="color: var(--color-text);">
+            <Truck class="w-5 h-5" aria-hidden="true" />
+            Historial de Compras
+          </h2>
           <BaseButton variant="success" size="sm" @click="abrirModalCompra">
+            <Plus class="w-4 h-4" aria-hidden="true" />
             Registrar Nueva Compra
           </BaseButton>
         </div>
@@ -179,6 +194,7 @@
               :disabled="currentPageCompras === 1"
               @click="currentPageCompras--"
             >
+              <ChevronLeft class="w-4 h-4" aria-hidden="true" />
               Anterior
             </BaseButton>
             <BaseButton
@@ -188,6 +204,7 @@
               @click="currentPageCompras++"
             >
               Siguiente
+              <ChevronRight class="w-4 h-4" aria-hidden="true" />
             </BaseButton>
           </div>
         </div>
@@ -241,9 +258,11 @@
 
       <template #footer>
         <BaseButton variant="secondary" @click="showModal = false">
+          <X class="w-4 h-4" aria-hidden="true" />
           Cancelar
         </BaseButton>
         <BaseButton variant="success" type="submit" form="purchase-form">
+          <Check class="w-4 h-4" aria-hidden="true" />
           Registrar Entrada
         </BaseButton>
       </template>
@@ -257,6 +276,18 @@ import api from "@/axios";
 import dayjs from "dayjs";
 import Swal from "sweetalert2";
 import { BaseButton, BaseInput, BaseSelect, BaseModal } from "@/components/ui";
+import {
+  Boxes,
+  ShoppingCart,
+  Truck,
+  Receipt,
+  DollarSign,
+  Plus,
+  ChevronLeft,
+  ChevronRight,
+  X,
+  Check,
+} from "lucide-vue-next";
 
 const tab = ref("ventas");
 const ventas = ref([]);

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -24,9 +24,6 @@
         <div class="auth-field">
           <label class="login-label">Correo electrónico</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
-            </svg>
             <input v-model="email" type="email" class="login-input" placeholder="tu@correo.com" required />
           </div>
         </div>
@@ -34,28 +31,15 @@
         <div class="auth-field">
           <label class="login-label">Contraseña</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-            </svg>
             <input v-model="password" :type="showPassword ? 'text' : 'password'" class="login-input pr-11" placeholder="••••••••" required />
             <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
-              <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-              </svg>
+              {{ showPassword ? 'Ocultar' : 'Ver' }}
             </button>
           </div>
         </div>
 
         <div class="pt-2">
           <button type="submit" :disabled="loading" class="auth-submit-btn">
-            <svg v-if="loading" class="animate-spin mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
             {{ loading ? 'Ingresando...' : 'Iniciar Sesión' }}
           </button>
         </div>
@@ -72,6 +56,7 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+
 import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/useAuthStore'
 import api from '@/axios'

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -23,24 +23,28 @@
 
         <div class="auth-field">
           <label class="login-label">Correo electrónico</label>
-          <div class="auth-input-wrap">
-            <input v-model="email" type="email" class="login-input" placeholder="tu@correo.com" required />
+          <div class="auth-input-wrap relative">
+            <Mail class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="email" type="email" class="login-input pl-10" placeholder="tu@correo.com" required />
           </div>
         </div>
 
         <div class="auth-field">
           <label class="login-label">Contraseña</label>
-          <div class="auth-input-wrap">
-            <input v-model="password" :type="showPassword ? 'text' : 'password'" class="login-input pr-11" placeholder="••••••••" required />
-            <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
-              {{ showPassword ? 'Ocultar' : 'Ver' }}
+          <div class="auth-input-wrap relative">
+            <Lock class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="password" :type="showPassword ? 'text' : 'password'" class="login-input pl-10 pr-11" placeholder="••••••••" required />
+            <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1" :aria-label="showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'">
+              <component :is="showPassword ? EyeOff : Eye" class="w-4 h-4" aria-hidden="true" />
             </button>
           </div>
         </div>
 
         <div class="pt-2">
-          <button type="submit" :disabled="loading" class="auth-submit-btn">
-            {{ loading ? 'Ingresando...' : 'Iniciar Sesión' }}
+          <button type="submit" :disabled="loading" class="auth-submit-btn inline-flex items-center justify-center gap-2">
+            <Loader2 v-if="loading" class="w-4 h-4 animate-spin" aria-hidden="true" />
+            <LogIn v-else class="w-4 h-4" aria-hidden="true" />
+            <span>{{ loading ? 'Ingresando...' : 'Iniciar Sesión' }}</span>
           </button>
         </div>
       </form>
@@ -61,6 +65,7 @@ import { useRouter } from 'vue-router'
 import { useAuthStore } from '@/stores/useAuthStore'
 import api from '@/axios'
 import Swal from 'sweetalert2'
+import { Mail, Lock, Eye, EyeOff, Loader2, LogIn } from 'lucide-vue-next'
 
 const email = ref('')
 const password = ref('')

--- a/src/views/MemberDetail.vue
+++ b/src/views/MemberDetail.vue
@@ -5,18 +5,13 @@
         to="/members"
         class="inline-flex items-center gap-1.5 text-sm font-medium text-muted hover:text-default transition mb-5"
       >
-        <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-          <path stroke-linecap="round" stroke-linejoin="round" d="M10 19l-7-7m0 0l7-7m-7 7h18" />
-        </svg>
+        ←
         Volver a clientes
       </router-link>
 
       <div v-if="loading" class="py-20 text-center">
         <div class="inline-flex items-center gap-3 text-muted">
-          <svg class="w-5 h-5 animate-spin text-primary-600" viewBox="0 0 24 24" fill="none">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-          </svg>
+          
           Cargando detalle...
         </div>
       </div>
@@ -35,22 +30,16 @@
             </div>
             <div class="relative flex items-start justify-between gap-4">
               <div class="flex items-center gap-2 text-white/70 text-xs font-semibold uppercase tracking-widest">
-                <svg class="w-4 h-4" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z" />
-                </svg>
+                
                 Ficha del cliente
               </div>
               <div class="flex gap-2">
                 <router-link :to="{ name: 'MemberEdit', params: { id: member.id } }" class="btn-ghost-white">
-                  <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                    <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                  </svg>
+                  
                   Editar
                 </router-link>
                 <a v-if="member.phone" :href="`https://wa.me/${formatearTelefono(member.phone)}`" target="_blank" class="btn-ghost-white">
-                  <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                    <path d="M20.52 3.48A11.8 11.8 0 0012.04 0C5.52 0 .17 5.35.14 11.87a11.82 11.82 0 001.58 5.94L0 24l6.35-1.67a11.83 11.83 0 005.68 1.45h.01c6.52 0 11.87-5.35 11.9-11.87a11.78 11.78 0 00-3.42-8.43z" />
-                  </svg>
+                  
                   WhatsApp
                 </a>
               </div>
@@ -73,21 +62,15 @@
                   <BaseBadge v-else color="gray">Sin plan</BaseBadge>
 
                   <span v-if="member.identification" class="meta-chip">
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M10 6H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V8a2 2 0 00-2-2h-5m-4 0V4a2 2 0 114 0v2m-4 0a2 2 0 104 0" />
-                    </svg>
+                    
                     {{ member.identification }}
                   </span>
                   <span v-if="member.phone" class="meta-chip">
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3 5a2 2 0 012-2h3.28a1 1 0 01.948.684l1.498 4.493a1 1 0 01-.502 1.21l-2.257 1.13a11.042 11.042 0 005.516 5.516l1.13-2.257a1 1 0 011.21-.502l4.493 1.498a1 1 0 01.684.949V19a2 2 0 01-2 2h-1C9.716 21 3 14.284 3 6V5z" />
-                    </svg>
+                    
                     {{ member.phone }}
                   </span>
                   <span v-if="member.email" class="meta-chip">
-                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                      <path stroke-linecap="round" stroke-linejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                    </svg>
+                    
                     {{ member.email }}
                   </span>
                 </div>
@@ -100,9 +83,7 @@
         <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
           <div class="stat-card">
             <div class="stat-icon bg-primary-100 text-primary-700">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
+              
             </div>
             <div>
               <p class="stat-label">Edad</p>
@@ -111,9 +92,7 @@
           </div>
           <div class="stat-card">
             <div class="stat-icon bg-success-100 text-success-700">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 10h8M4 14h8M4 18h16" />
-              </svg>
+              
             </div>
             <div>
               <p class="stat-label">Estatura</p>
@@ -122,9 +101,7 @@
           </div>
           <div class="stat-card">
             <div class="stat-icon bg-success-100 text-success-700">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6 3v3M18 3v3M3 9h18M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
-              </svg>
+              
             </div>
             <div>
               <p class="stat-label">Peso</p>
@@ -133,9 +110,7 @@
           </div>
           <div class="stat-card">
             <div class="stat-icon" :class="imcIconCls">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-              </svg>
+              
             </div>
             <div>
               <p class="stat-label">IMC</p>
@@ -244,9 +219,7 @@
 
             <div v-else class="detail-card text-center">
               <div class="w-12 h-12 rounded-full bg-[var(--color-overlay)] flex items-center justify-center mx-auto mb-3">
-                <svg class="w-6 h-6 text-subtle" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 5v2m0 4v2m0 4v2M5 5a2 2 0 00-2 2v3a2 2 0 110 4v3a2 2 0 002 2h14a2 2 0 002-2v-3a2 2 0 110-4V7a2 2 0 00-2-2H5z" />
-                </svg>
+                
               </div>
               <p class="text-sm text-muted">Sin membresía asignada</p>
             </div>

--- a/src/views/MemberDetail.vue
+++ b/src/views/MemberDetail.vue
@@ -5,13 +5,13 @@
         to="/members"
         class="inline-flex items-center gap-1.5 text-sm font-medium text-muted hover:text-default transition mb-5"
       >
-        ←
+        <ArrowLeft class="w-4 h-4" aria-hidden="true" />
         Volver a clientes
       </router-link>
 
       <div v-if="loading" class="py-20 text-center">
         <div class="inline-flex items-center gap-3 text-muted">
-          
+          <Loader2 class="w-5 h-5 animate-spin" aria-hidden="true" />
           Cargando detalle...
         </div>
       </div>
@@ -30,16 +30,16 @@
             </div>
             <div class="relative flex items-start justify-between gap-4">
               <div class="flex items-center gap-2 text-white/70 text-xs font-semibold uppercase tracking-widest">
-                
+                <FileText class="w-4 h-4" aria-hidden="true" />
                 Ficha del cliente
               </div>
               <div class="flex gap-2">
                 <router-link :to="{ name: 'MemberEdit', params: { id: member.id } }" class="btn-ghost-white">
-                  
+                  <Pencil class="w-4 h-4" aria-hidden="true" />
                   Editar
                 </router-link>
                 <a v-if="member.phone" :href="`https://wa.me/${formatearTelefono(member.phone)}`" target="_blank" class="btn-ghost-white">
-                  
+                  <MessageCircle class="w-4 h-4" aria-hidden="true" />
                   WhatsApp
                 </a>
               </div>
@@ -62,15 +62,15 @@
                   <BaseBadge v-else color="gray">Sin plan</BaseBadge>
 
                   <span v-if="member.identification" class="meta-chip">
-                    
+                    <IdCard class="w-4 h-4" aria-hidden="true" />
                     {{ member.identification }}
                   </span>
                   <span v-if="member.phone" class="meta-chip">
-                    
+                    <Phone class="w-4 h-4" aria-hidden="true" />
                     {{ member.phone }}
                   </span>
                   <span v-if="member.email" class="meta-chip">
-                    
+                    <Mail class="w-4 h-4" aria-hidden="true" />
                     {{ member.email }}
                   </span>
                 </div>
@@ -83,7 +83,7 @@
         <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
           <div class="stat-card">
             <div class="stat-icon bg-primary-100 text-primary-700">
-              
+              <Cake class="w-5 h-5" aria-hidden="true" />
             </div>
             <div>
               <p class="stat-label">Edad</p>
@@ -92,7 +92,7 @@
           </div>
           <div class="stat-card">
             <div class="stat-icon bg-success-100 text-success-700">
-              
+              <Ruler class="w-5 h-5" aria-hidden="true" />
             </div>
             <div>
               <p class="stat-label">Estatura</p>
@@ -101,7 +101,7 @@
           </div>
           <div class="stat-card">
             <div class="stat-icon bg-success-100 text-success-700">
-              
+              <Weight class="w-5 h-5" aria-hidden="true" />
             </div>
             <div>
               <p class="stat-label">Peso</p>
@@ -110,7 +110,7 @@
           </div>
           <div class="stat-card">
             <div class="stat-icon" :class="imcIconCls">
-              
+              <Activity class="w-5 h-5" aria-hidden="true" />
             </div>
             <div>
               <p class="stat-label">IMC</p>
@@ -236,6 +236,20 @@ import { useRoute } from "vue-router";
 import api from "@/axios";
 import dayjs from "dayjs";
 import Swal from "sweetalert2";
+import {
+  Activity,
+  ArrowLeft,
+  Cake,
+  FileText,
+  IdCard,
+  Loader2,
+  Mail,
+  MessageCircle,
+  Pencil,
+  Phone,
+  Ruler,
+  Weight,
+} from 'lucide-vue-next'
 import { BaseBadge } from "@/components/ui";
 
 const route = useRoute();

--- a/src/views/MemberEdit.vue
+++ b/src/views/MemberEdit.vue
@@ -5,7 +5,7 @@
       <div class="flex items-center justify-between px-6 sm:px-8 py-5 border-b border-default-soft">
         <div class="flex items-center gap-4">
           <div class="w-11 h-11 rounded-xl bg-primary-100 flex items-center justify-center shrink-0">
-            
+            <User class="w-5 h-5 text-primary-700" aria-hidden="true" />
           </div>
           <div>
             <h1 class="text-xl font-bold text-default tracking-tight leading-tight">
@@ -21,7 +21,7 @@
           class="p-2 hover:bg-[var(--color-overlay)] rounded-full transition-colors"
           aria-label="Cerrar"
         >
-          ✕
+          <X class="w-5 h-5 text-muted" aria-hidden="true" />
         </router-link>
       </div>
 
@@ -185,6 +185,7 @@
 import { reactive, ref, onMounted } from "vue";
 
 import { useRoute, useRouter } from "vue-router";
+import { User, X } from 'lucide-vue-next'
 import api from "@/axios";
 import Swal from "sweetalert2";
 import FingerprintEnroll from "@/components/FingerprintEnroll.vue";

--- a/src/views/MemberEdit.vue
+++ b/src/views/MemberEdit.vue
@@ -164,6 +164,7 @@
       <!-- Footer -->
       <div class="px-6 sm:px-8 py-5 border-t border-default-soft bg-[var(--color-surface-soft)] flex items-center justify-end gap-3">
         <BaseButton variant="secondary" @click="router.push({ name: 'Members' })">
+          <X class="w-4 h-4 mr-2 inline" aria-hidden="true" />
           Cancelar
         </BaseButton>
         <BaseButton
@@ -174,6 +175,7 @@
           :loading="loading"
           :disabled="loading"
         >
+          <Save class="w-4 h-4 mr-2 inline" aria-hidden="true" />
           Guardar Cambios
         </BaseButton>
       </div>
@@ -185,7 +187,7 @@
 import { reactive, ref, onMounted } from "vue";
 
 import { useRoute, useRouter } from "vue-router";
-import { User, X } from 'lucide-vue-next'
+import { User, X, Save } from 'lucide-vue-next'
 import api from "@/axios";
 import Swal from "sweetalert2";
 import FingerprintEnroll from "@/components/FingerprintEnroll.vue";

--- a/src/views/MemberEdit.vue
+++ b/src/views/MemberEdit.vue
@@ -5,9 +5,7 @@
       <div class="flex items-center justify-between px-6 sm:px-8 py-5 border-b border-default-soft">
         <div class="flex items-center gap-4">
           <div class="w-11 h-11 rounded-xl bg-primary-100 flex items-center justify-center shrink-0">
-            <svg class="w-6 h-6 text-primary-700" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-            </svg>
+            
           </div>
           <div>
             <h1 class="text-xl font-bold text-default tracking-tight leading-tight">
@@ -23,9 +21,7 @@
           class="p-2 hover:bg-[var(--color-overlay)] rounded-full transition-colors"
           aria-label="Cerrar"
         >
-          <svg class="w-5 h-5 text-muted" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          ✕
         </router-link>
       </div>
 
@@ -187,6 +183,7 @@
 
 <script setup>
 import { reactive, ref, onMounted } from "vue";
+
 import { useRoute, useRouter } from "vue-router";
 import api from "@/axios";
 import Swal from "sweetalert2";

--- a/src/views/Members.vue
+++ b/src/views/Members.vue
@@ -9,17 +9,24 @@
           <p class="text-sm text-subtle mt-0.5">Gestión de clientes y membresías</p>
         </div>
         <div class="flex flex-wrap gap-2 w-full sm:w-auto">
-          <router-link to="/Menu" class="btn btn-dark flex-1 sm:flex-none">Inicio</router-link>
-          <button @click="showRegisterModal = true" class="btn btn-success flex-1 sm:flex-none">Nuevo cliente</button>
+          <router-link to="/Menu" class="btn btn-dark flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <Home class="w-4 h-4" aria-hidden="true" />
+            <span>Inicio</span>
+          </router-link>
+          <button @click="showRegisterModal = true" class="btn btn-success flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <UserPlus class="w-4 h-4" aria-hidden="true" />
+            <span>Nuevo cliente</span>
+          </button>
         </div>
       </div>
 
-      <div class="mb-6">
+      <div class="mb-6 relative">
+        <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
         <input
           v-model="busqueda"
           type="text"
           placeholder="Buscar por nombre o teléfono..."
-          class="field-input"
+          class="field-input pl-10"
         />
       </div>
 
@@ -62,14 +69,15 @@
             </div>
             <button
               @click="toggleDetalle(member.id)"
-              class="text-xs font-bold px-3 py-1 rounded-full border transition-all h-8 flex items-center select-none"
+              class="text-xs font-bold px-3 py-1 rounded-full border transition-all h-8 inline-flex items-center gap-1 select-none"
               :class="
                 detallesAbiertos.includes(member.id)
                   ? 'detail-toggle-active'
                   : 'bg-[var(--color-overlay)] text-muted border-default-soft'
               "
             >
-              {{ detallesAbiertos.includes(member.id) ? "Ocultar" : "Ver más" }}
+              <component :is="detallesAbiertos.includes(member.id) ? ChevronUp : ChevronDown" class="w-3.5 h-3.5" aria-hidden="true" />
+              <span>{{ detallesAbiertos.includes(member.id) ? "Ocultar" : "Ver más" }}</span>
             </button>
           </div>
 
@@ -99,7 +107,7 @@
                 class="action-btn action-primary"
                 @click="abrirDetalle(member)"
               >
-                
+                <Eye class="w-3.5 h-3.5" aria-hidden="true" />
                 Detalle
               </button>
 
@@ -109,7 +117,7 @@
                 target="_blank"
                 class="action-btn action-success"
               >
-                
+                <MessageCircle class="w-3.5 h-3.5" aria-hidden="true" />
                 WhatsApp
               </a>
 
@@ -117,7 +125,7 @@
                 :to="{ name: 'MemberEdit', params: { id: member.id } }"
                 class="action-btn action-neutral"
               >
-                
+                <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
                 Editar
               </router-link>
 
@@ -126,12 +134,12 @@
                 :class="member.memberships?.[0]?.status === 'expired' ? 'action-warning' : 'action-indigo'"
                 @click="abrirAsignar(member)"
               >
-                
+                <component :is="member.memberships?.[0]?.status === 'expired' ? RefreshCw : CalendarCheck2" class="w-3.5 h-3.5" aria-hidden="true" />
                 {{ member.memberships?.[0]?.status === "expired" ? "Renovar" : "Membresía" }}
               </button>
 
               <button class="action-btn action-success" @click="abrirPagar(member)">
-                
+                <DollarSign class="w-3.5 h-3.5" aria-hidden="true" />
                 Pagar
               </button>
             </div>
@@ -144,12 +152,14 @@
         <span>Página {{ currentPageMiembros }} de {{ totalMiembrosPages }} ({{ miembrosFiltrados.length }} clientes)</span>
         <div class="flex gap-1">
           <button @click="currentPageMiembros--" :disabled="currentPageMiembros === 1"
-            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed">
-            Anterior
+            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1">
+            <ChevronLeft class="w-4 h-4" aria-hidden="true" />
+            <span>Anterior</span>
           </button>
           <button @click="currentPageMiembros++" :disabled="currentPageMiembros === totalMiembrosPages"
-            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed">
-            Siguiente
+            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1">
+            <span>Siguiente</span>
+            <ChevronRight class="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -193,6 +203,21 @@ import { ref, computed, watch, onMounted } from "vue";
 import api from "@/axios";
 import Sidebar from "@/views/Sidebar.vue";
 import Swal from "sweetalert2";
+import {
+  Home,
+  UserPlus,
+  Search,
+  Eye,
+  Pencil,
+  MessageCircle,
+  CalendarCheck2,
+  RefreshCw,
+  DollarSign,
+  ChevronLeft,
+  ChevronRight,
+  ChevronDown,
+  ChevronUp,
+} from "lucide-vue-next";
 
 // Importar Componentes Hijos
 import MemberRegisterModal from "@/components/members/MemberRegisterModal.vue";

--- a/src/views/Members.vue
+++ b/src/views/Members.vue
@@ -99,10 +99,7 @@
                 class="action-btn action-primary"
                 @click="abrirDetalle(member)"
               >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M2.458 12C3.732 7.943 7.523 5 12 5c4.478 0 8.268 2.943 9.542 7-1.274 4.057-5.064 7-9.542 7-4.477 0-8.268-2.943-9.542-7z" />
-                </svg>
+                
                 Detalle
               </button>
 
@@ -112,9 +109,7 @@
                 target="_blank"
                 class="action-btn action-success"
               >
-                <svg class="w-3.5 h-3.5" fill="currentColor" viewBox="0 0 24 24">
-                  <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884" />
-                </svg>
+                
                 WhatsApp
               </a>
 
@@ -122,9 +117,7 @@
                 :to="{ name: 'MemberEdit', params: { id: member.id } }"
                 class="action-btn action-neutral"
               >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-                </svg>
+                
                 Editar
               </router-link>
 
@@ -133,16 +126,12 @@
                 :class="member.memberships?.[0]?.status === 'expired' ? 'action-warning' : 'action-indigo'"
                 @click="abrirAsignar(member)"
               >
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-                </svg>
+                
                 {{ member.memberships?.[0]?.status === "expired" ? "Renovar" : "Membresía" }}
               </button>
 
               <button class="action-btn action-success" @click="abrirPagar(member)">
-                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-                  <path stroke-linecap="round" stroke-linejoin="round" d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z" />
-                </svg>
+                
                 Pagar
               </button>
             </div>
@@ -200,6 +189,7 @@
 
 <script setup>
 import { ref, computed, watch, onMounted } from "vue";
+
 import api from "@/axios";
 import Sidebar from "@/views/Sidebar.vue";
 import Swal from "sweetalert2";

--- a/src/views/Membership.vue
+++ b/src/views/Membership.vue
@@ -9,8 +9,14 @@
           <p class="page-subtitle">{{ tituloFiltro }}</p>
         </div>
         <div class="flex flex-wrap gap-2 w-full sm:w-auto">
-          <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none">Inicio</router-link>
-          <button @click="showModal = true" class="btn btn-success flex-1 sm:flex-none">Asignar membresía</button>
+          <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <Home class="w-4 h-4" aria-hidden="true" />
+            <span>Inicio</span>
+          </router-link>
+          <button @click="showModal = true" class="btn btn-success flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <Plus class="w-4 h-4" aria-hidden="true" />
+            <span>Asignar membresía</span>
+          </button>
         </div>
       </div>
 
@@ -45,12 +51,13 @@
         </button>
       </div>
 
-      <div class="mb-4">
+      <div class="mb-4 relative">
+        <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
         <input
           v-model="busquedaMembresia"
           type="text"
           placeholder="Buscar miembro..."
-          class="field-input"
+          class="field-input pl-10"
         />
       </div>
 
@@ -113,6 +120,7 @@
                     class="btn btn-sm bg-orange-500 hover:bg-orange-600 text-white shadow-sm flex items-center gap-1"
                     title="Renovar Membresía"
                   >
+                    <RefreshCw class="w-3.5 h-3.5" aria-hidden="true" />
                     Renovar
                   </button>
 
@@ -123,6 +131,7 @@
                     @click="abrirEditarModal(m)"
                     title="Editar / Corregir"
                   >
+                    <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
                     Editar
                   </button>
                 </div>
@@ -139,9 +148,10 @@
           <button
             @click="cambiarPagina(currentPage - 1)"
             :disabled="currentPage === 1"
-            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed"
+            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
           >
-            ← Anterior
+            <ChevronLeft class="w-4 h-4" aria-hidden="true" />
+            <span>Anterior</span>
           </button>
           <button
             v-for="page in paginasVisibles"
@@ -155,9 +165,10 @@
           <button
             @click="cambiarPagina(currentPage + 1)"
             :disabled="currentPage === lastPage"
-            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed"
+            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1"
           >
-            Siguiente →
+            <span>Siguiente</span>
+            <ChevronRight class="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -169,6 +180,7 @@
       >
         <div class="w-full max-w-sm p-6 rounded-xl shadow-2xl" :style="{ background: 'var(--modal-panel-bg)', border: '1px solid var(--modal-panel-border)' }">
           <h2 id="membership-edit-modal-title" class="font-bold text-lg mb-4 border-b border-default-soft pb-2 flex items-center gap-2 text-default">
+            <Pencil class="w-5 h-5" aria-hidden="true" />
             Editar Membresía
           </h2>
           <form @submit.prevent="guardarCambios" class="space-y-3">
@@ -211,10 +223,14 @@
             </div>
 
             <div class="flex justify-end gap-2 mt-4 pt-2 border-t">
-              <button type="button" @click="cerrarEditarModal" class="btn btn-secondary">
-                Cancelar
+              <button type="button" @click="cerrarEditarModal" class="btn btn-secondary inline-flex items-center gap-2">
+                <X class="w-4 h-4" aria-hidden="true" />
+                <span>Cancelar</span>
               </button>
-              <button type="submit" class="btn btn-primary">Guardar</button>
+              <button type="submit" class="btn btn-primary inline-flex items-center gap-2">
+                <Check class="w-4 h-4" aria-hidden="true" />
+                <span>Guardar</span>
+              </button>
             </div>
           </form>
         </div>
@@ -227,6 +243,7 @@
       >
         <div class="w-full max-w-md p-6 rounded-xl shadow-2xl" :style="{ background: 'var(--modal-panel-bg)', border: '1px solid var(--modal-panel-border)' }">
           <h2 id="membership-assign-modal-title" class="font-bold text-lg mb-4 border-b border-default-soft pb-2 flex items-center gap-2 text-default">
+            <CalendarCheck2 class="w-5 h-5" aria-hidden="true" />
             {{ form.member_id ? "Asignar membresía a " + busqueda : "Asignar Nueva" }}
           </h2>
           <form @submit.prevent="asignarMembresia" class="space-y-4">
@@ -267,8 +284,14 @@
             </div>
 
             <div class="flex justify-end gap-2 pt-2">
-              <button type="button" @click="cerrarModal" class="btn btn-secondary">Cancelar</button>
-              <button type="submit" class="btn btn-success">Asignar</button>
+              <button type="button" @click="cerrarModal" class="btn btn-secondary inline-flex items-center gap-2">
+                <X class="w-4 h-4" aria-hidden="true" />
+                <span>Cancelar</span>
+              </button>
+              <button type="submit" class="btn btn-success inline-flex items-center gap-2">
+                <Check class="w-4 h-4" aria-hidden="true" />
+                <span>Asignar</span>
+              </button>
             </div>
           </form>
         </div>
@@ -287,6 +310,18 @@ import utc from "dayjs/plugin/utc";
 
 dayjs.extend(utc);
 import Swal from "sweetalert2";
+import {
+  Home,
+  Plus,
+  Search,
+  Pencil,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+  CalendarCheck2,
+  X,
+  Check,
+} from "lucide-vue-next";
 
 const route = useRoute();
 

--- a/src/views/Membership.vue
+++ b/src/views/Membership.vue
@@ -27,21 +27,21 @@
           class="btn btn-sm whitespace-nowrap"
           :class="statusFilter === 'active' ? 'btn-primary' : 'btn-secondary'"
         >
-          ✅ Activas
+          Activas
         </button>
         <button
           @click="filtrarMembresias('inactive_unpaid')"
           class="btn btn-sm whitespace-nowrap"
           :class="statusFilter === 'inactive_unpaid' ? 'btn-primary' : 'btn-secondary'"
         >
-          ⏳ Por Pagar
+          Por Pagar
         </button>
         <button
           @click="filtrarMembresias('expiring_soon')"
           class="btn btn-sm whitespace-nowrap"
           :class="statusFilter === 'expiring_soon' ? 'btn-primary' : 'btn-secondary'"
         >
-          ⚠️ Vencen Pronto
+          Vencen Pronto
         </button>
       </div>
 
@@ -85,7 +85,7 @@
               </td>
 
               <td class="py-3 px-4 text-xs text-muted">
-                {{ formatDate(m.start_date) }} ➝ {{ formatDate(m.end_date) }}
+                {{ formatDate(m.start_date) }} → {{ formatDate(m.end_date) }}
               </td>
 
               <td class="py-3 px-4 text-center">
@@ -113,7 +113,7 @@
                     class="btn btn-sm bg-orange-500 hover:bg-orange-600 text-white shadow-sm flex items-center gap-1"
                     title="Renovar Membresía"
                   >
-                    <span>🔄</span> Renovar
+                    Renovar
                   </button>
 
                   <!-- Mostrar Editar solo si NO está vencida (activa, pendiente, etc.) -->
@@ -123,7 +123,7 @@
                     @click="abrirEditarModal(m)"
                     title="Editar / Corregir"
                   >
-                    <span>✏️</span> Editar
+                    Editar
                   </button>
                 </div>
               </td>
@@ -279,6 +279,7 @@
 
 <script setup>
 import { ref, onMounted, computed, watch } from "vue";
+
 import { useRoute } from "vue-router";
 import api from "@/axios";
 import dayjs from "dayjs";

--- a/src/views/Membership.vue
+++ b/src/views/Membership.vue
@@ -186,11 +186,11 @@
           <form @submit.prevent="guardarCambios" class="space-y-3">
             <div>
               <label class="text-xs font-bold uppercase text-subtle">Plan</label>
-              <select v-model="editarMembresia.plan.id" class="field-input">
-                <option v-for="plan in planes" :key="plan.id" :value="plan.id">
-                  {{ plan.membership_type?.name }} ({{ traducirFrecuencia(plan.frequency) }})
-                </option>
-              </select>
+              <BaseSelect
+                v-model="editarMembresia.plan.id"
+                :options="planEditOptions"
+                placeholder="Seleccione un plan"
+              />
             </div>
 
             <div class="grid grid-cols-2 gap-3">
@@ -214,12 +214,10 @@
 
             <div>
               <label class="text-xs font-bold uppercase text-subtle">Estado</label>
-              <select v-model="editarMembresia.status" class="field-input">
-                <option value="active">Activa</option>
-                <option value="expired">Vencida</option>
-                <option value="inactive_unpaid">Por Pagar</option>
-                <option value="cancelled">Cancelada</option>
-              </select>
+              <BaseSelect
+                v-model="editarMembresia.status"
+                :options="estadoMembresiaOptions"
+              />
             </div>
 
             <div class="flex justify-end gap-2 mt-4 pt-2 border-t">
@@ -273,14 +271,12 @@
 
             <div>
               <label class="text-xs font-bold uppercase text-subtle">Plan</label>
-              <select v-model="form.plan_id" class="field-input" required>
-                <option disabled value="">Seleccione...</option>
-                <option v-for="p in planes" :key="p.id" :value="p.id">
-                  {{ p.membership_type?.name }} - {{ traducirFrecuencia(p.frequency) }} - ${
-                    parseInt(p.price).toLocaleString()
-                  }}
-                </option>
-              </select>
+              <BaseSelect
+                v-model="form.plan_id"
+                :options="planAsignarOptions"
+                placeholder="Seleccione..."
+                required
+              />
             </div>
 
             <div class="flex justify-end gap-2 pt-2">
@@ -322,6 +318,7 @@ import {
   X,
   Check,
 } from "lucide-vue-next";
+import { BaseSelect } from "@/components/ui";
 
 const route = useRoute();
 
@@ -545,6 +542,27 @@ const traducirFrecuencia = (f) => {
   const map = { daily: "Diaria", weekly: "Semanal", biweekly: "Quincenal", monthly: "Mensual" };
   return map[f] || f;
 };
+
+const planEditOptions = computed(() =>
+  planes.value.map((p) => ({
+    value: p.id,
+    label: `${p.membership_type?.name || "Plan"} (${traducirFrecuencia(p.frequency)})`,
+  }))
+);
+
+const planAsignarOptions = computed(() =>
+  planes.value.map((p) => ({
+    value: p.id,
+    label: `${p.membership_type?.name || "Plan"} - ${traducirFrecuencia(p.frequency)} - $${parseInt(p.price).toLocaleString()}`,
+  }))
+);
+
+const estadoMembresiaOptions = [
+  { value: "active", label: "Activa" },
+  { value: "expired", label: "Vencida" },
+  { value: "inactive_unpaid", label: "Por Pagar" },
+  { value: "cancelled", label: "Cancelada" },
+];
 
 const traducirEstado = (s) => {
   const map = {

--- a/src/views/MembershipPlans.vue
+++ b/src/views/MembershipPlans.vue
@@ -2,10 +2,12 @@
   <div class="page-layout">
     <BaseCard title="Planes de Membresía" subtitle="Gestiona los planes disponibles" class="space-y-6">
       <template #actions>
-        <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none">
-          Inicio
+        <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+          <Home class="w-4 h-4" aria-hidden="true" />
+          <span>Inicio</span>
         </router-link>
         <BaseButton variant="success" class="flex-1 sm:flex-none" @click="openModal = true">
+          <Plus class="w-4 h-4" aria-hidden="true" />
           Nuevo plan
         </BaseButton>
       </template>
@@ -32,9 +34,11 @@
               <td>
                 <div class="flex justify-center gap-2">
                   <BaseButton variant="indigo" size="sm" @click="editarPlan(plan)">
+                    <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
                     Editar
                   </BaseButton>
                   <BaseButton variant="danger" size="sm" @click="eliminarPlan(plan.id)">
+                    <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
                     Eliminar
                   </BaseButton>
                 </div>
@@ -56,6 +60,7 @@
             :disabled="currentPagePlanes === 1"
             @click="currentPagePlanes--"
           >
+            <ChevronLeft class="w-4 h-4" aria-hidden="true" />
             Anterior
           </BaseButton>
           <BaseButton
@@ -65,6 +70,7 @@
             @click="currentPagePlanes++"
           >
             Siguiente
+            <ChevronRight class="w-4 h-4" aria-hidden="true" />
           </BaseButton>
         </div>
       </div>
@@ -99,8 +105,12 @@
       </form>
 
       <template #footer>
-        <BaseButton variant="secondary" @click="openModal = false">Cancelar</BaseButton>
+        <BaseButton variant="secondary" @click="openModal = false">
+          <X class="w-4 h-4" aria-hidden="true" />
+          Cancelar
+        </BaseButton>
         <BaseButton variant="primary" type="submit" form="create-plan-form">
+          <Check class="w-4 h-4" aria-hidden="true" />
           Guardar
         </BaseButton>
       </template>
@@ -135,8 +145,12 @@
       </form>
 
       <template #footer>
-        <BaseButton variant="secondary" @click="cerrarModalEdicion">Cancelar</BaseButton>
+        <BaseButton variant="secondary" @click="cerrarModalEdicion">
+          <X class="w-4 h-4" aria-hidden="true" />
+          Cancelar
+        </BaseButton>
         <BaseButton variant="primary" type="submit" form="edit-plan-form">
+          <Check class="w-4 h-4" aria-hidden="true" />
           Actualizar
         </BaseButton>
       </template>
@@ -150,6 +164,16 @@ import api from "@/axios";
 import Swal from "sweetalert2";
 import { BaseButton, BaseInput, BaseSelect, BaseCard, BaseBadge, BaseModal } from "@/components/ui";
 import { SWAL_COLORS } from "@/lib/colors";
+import {
+  Home,
+  Plus,
+  Pencil,
+  Trash2,
+  ChevronLeft,
+  ChevronRight,
+  X,
+  Check,
+} from "lucide-vue-next";
 
 // Opciones compartidas para los selects de frecuencia.
 const FREQUENCY_OPTIONS = [

--- a/src/views/Menu.vue
+++ b/src/views/Menu.vue
@@ -78,29 +78,21 @@
         </router-link>
       </div>
 
-      <!-- ═══════════ Acceso rápido ═══════════ -->
+      <!-- ═══════════ Acceso rápido (marquee CSS) ═══════════ -->
       <p class="section-label mb-4">Acceso Rápido</p>
-      <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
-
-        <router-link to="/pos" class="quick-card group" style="--qc:#6366f1">
-          <ShoppingCart class="w-6 h-6 mb-2" aria-hidden="true" />
-          <span class="quick-label">Punto de Venta</span>
-        </router-link>
-
-        <router-link to="/members" class="quick-card group" style="--qc:#34d399">
-          <Users class="w-6 h-6 mb-2" aria-hidden="true" />
-          <span class="quick-label">Clientes</span>
-        </router-link>
-
-        <router-link to="/Membership" class="quick-card group" style="--qc:#38bdf8">
-          <CalendarCheck2 class="w-6 h-6 mb-2" aria-hidden="true" />
-          <span class="quick-label">Membresías</span>
-        </router-link>
-
-        <router-link to="/CashBox" class="quick-card group" style="--qc:#2dd4bf">
-          <BadgeDollarSign class="w-6 h-6 mb-2" aria-hidden="true" />
-          <span class="quick-label">Caja</span>
-        </router-link>
+      <div class="marquee">
+        <div class="marquee-track">
+          <router-link
+            v-for="(item, i) in quickItemsRepeated"
+            :key="i"
+            :to="item.to"
+            class="quick-card group marquee-card"
+            :style="{ '--qc': item.color }"
+          >
+            <component :is="item.icon" class="w-6 h-6 mb-2" aria-hidden="true" />
+            <span class="quick-label">{{ item.label }}</span>
+          </router-link>
+        </div>
       </div>
 
     </div>
@@ -122,6 +114,15 @@ import {
   CalendarCheck2,
   BadgeDollarSign,
 } from 'lucide-vue-next'
+const quickItemsBase = [
+  { to: '/pos',        label: 'Punto de Venta', color: '#6366f1', icon: ShoppingCart },
+  { to: '/members',    label: 'Clientes',       color: '#34d399', icon: Users },
+  { to: '/Membership', label: 'Membresías',     color: '#38bdf8', icon: CalendarCheck2 },
+  { to: '/CashBox',    label: 'Caja',           color: '#2dd4bf', icon: BadgeDollarSign },
+]
+// Duplicamos exactamente una vez. Con translateX(-50%) la animación cae
+// justo donde empieza la 2da copia, así el loop es invisible.
+const quickItemsRepeated = [...quickItemsBase, ...quickItemsBase]
 
 const auth  = useAuthStore()
 const user  = auth.user
@@ -156,3 +157,35 @@ onMounted(async () => {
   }
 })
 </script>
+
+<style scoped>
+.marquee {
+  overflow: hidden;
+  mask-image: linear-gradient(to right, transparent 0, #000 4%, #000 96%, transparent 100%);
+  -webkit-mask-image: linear-gradient(to right, transparent 0, #000 4%, #000 96%, transparent 100%);
+}
+
+.marquee-track {
+  display: flex;
+  gap: 1rem;
+  width: max-content;
+  animation: marquee-scroll 24s linear infinite;
+}
+
+.marquee:hover .marquee-track {
+  animation-play-state: paused;
+}
+
+.marquee-card {
+  flex: 0 0 auto;
+  width: 16rem;
+}
+@media (min-width: 640px) {
+  .marquee-card { width: 18rem; }
+}
+
+@keyframes marquee-scroll {
+  from { transform: translateX(0); }
+  to   { transform: translateX(calc(-50% - 0.5rem)); }
+}
+</style>

--- a/src/views/Menu.vue
+++ b/src/views/Menu.vue
@@ -32,6 +32,7 @@
         <div class="stat-card" style="background:linear-gradient(135deg,#059669 0%,#065f46 100%)">
           <div class="flex items-start justify-between mb-4">
             <p class="stat-tag" style="color:rgba(167,243,208,0.85)">Activos</p>
+            <UserCheck class="w-5 h-5" style="color:rgba(167,243,208,0.85)" aria-hidden="true" />
           </div>
           <p class="stat-num">{{ stats.active || 0 }}</p>
           <p class="stat-desc" style="color:rgba(167,243,208,0.6)">Membresías vigentes</p>
@@ -44,6 +45,7 @@
         >
           <div class="flex items-start justify-between mb-4">
             <p class="stat-tag" style="color:rgba(254,202,202,0.85)">Vencidos</p>
+            <AlertTriangle class="w-5 h-5" style="color:rgba(254,202,202,0.85)" aria-hidden="true" />
           </div>
           <p class="stat-num">{{ stats.expired || 0 }}</p>
           <p class="stat-desc" style="color:rgba(254,202,202,0.6)">Requieren renovación</p>
@@ -56,6 +58,7 @@
         >
           <div class="flex items-start justify-between mb-4">
             <p class="stat-tag" style="color:rgba(253,230,138,0.85)">Por Pagar</p>
+            <Clock class="w-5 h-5" style="color:rgba(253,230,138,0.85)" aria-hidden="true" />
           </div>
           <p class="stat-num">{{ stats.inactive_unpaid || 0 }}</p>
           <p class="stat-desc" style="color:rgba(253,230,138,0.6)">Pendientes de cobro</p>
@@ -68,6 +71,7 @@
         >
           <div class="flex items-start justify-between mb-4">
             <p class="stat-tag" style="color:rgba(191,219,254,0.85)">Vencen Pronto</p>
+            <CalendarClock class="w-5 h-5" style="color:rgba(191,219,254,0.85)" aria-hidden="true" />
           </div>
           <p class="stat-num">{{ stats.expiring_soon || 0 }}</p>
           <p class="stat-desc" style="color:rgba(191,219,254,0.6)">En los próximos días</p>
@@ -79,18 +83,22 @@
       <div class="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4">
 
         <router-link to="/pos" class="quick-card group" style="--qc:#6366f1">
+          <ShoppingCart class="w-6 h-6 mb-2" aria-hidden="true" />
           <span class="quick-label">Punto de Venta</span>
         </router-link>
 
         <router-link to="/members" class="quick-card group" style="--qc:#34d399">
+          <Users class="w-6 h-6 mb-2" aria-hidden="true" />
           <span class="quick-label">Clientes</span>
         </router-link>
 
         <router-link to="/Membership" class="quick-card group" style="--qc:#38bdf8">
+          <CalendarCheck2 class="w-6 h-6 mb-2" aria-hidden="true" />
           <span class="quick-label">Membresías</span>
         </router-link>
 
         <router-link to="/CashBox" class="quick-card group" style="--qc:#2dd4bf">
+          <BadgeDollarSign class="w-6 h-6 mb-2" aria-hidden="true" />
           <span class="quick-label">Caja</span>
         </router-link>
       </div>
@@ -104,6 +112,16 @@ import { ref, computed, onMounted } from 'vue'
 import { useAuthStore } from '@/stores/useAuthStore'
 import api from '@/axios'
 import Swal from 'sweetalert2'
+import {
+  UserCheck,
+  AlertTriangle,
+  Clock,
+  CalendarClock,
+  ShoppingCart,
+  Users,
+  CalendarCheck2,
+  BadgeDollarSign,
+} from 'lucide-vue-next'
 
 const auth  = useAuthStore()
 const user  = auth.user

--- a/src/views/POS.vue
+++ b/src/views/POS.vue
@@ -37,9 +37,9 @@
               class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 hover:text-red-500 transition-colors flex items-center justify-center cursor-pointer z-10"
               title="Borrar selección"
             >
-              ✕
+              <X class="w-5 h-5" aria-hidden="true" />
             </button>
-            <span v-else class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">&#8964;</span>
+            <ChevronDown v-else class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" aria-hidden="true" />
             <ul v-if="isClientDropdownOpen" class="absolute z-50 w-full mt-1 bg-white dark:bg-[#1f2937] border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
               <li
                 v-if="filteredClientOptions.length === 0"
@@ -60,7 +60,7 @@
           </div>
           <div class="flex-1 relative search-input-wrap">
             <div class="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none text-gray-400 dark:text-gray-500">
-              
+              <Search class="w-4 h-4" aria-hidden="true" />
             </div>
             <input v-model="search" type="text" placeholder="Buscar producto por nombre..." class="field-input text-sm pos-search-input">
           </div>
@@ -105,7 +105,7 @@
         <!-- Ticket items -->
         <div class="pos-ticket-items">
           <div v-if="cart.length === 0" class="h-full flex flex-col items-center justify-center opacity-40">
-            
+            <ShoppingCart class="w-8 h-8" aria-hidden="true" />
             <p class="text-sm" style="color: var(--color-text-subtle);">Carrito vacío</p>
           </div>
 
@@ -149,6 +149,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 
 import api from '@/axios'
+import { ChevronDown, Search, ShoppingCart, X } from 'lucide-vue-next'
 import Swal from 'sweetalert2'
 import dayjs from 'dayjs'
 

--- a/src/views/POS.vue
+++ b/src/views/POS.vue
@@ -3,12 +3,17 @@
 
     <!-- ═══ HEADER ═══ -->
     <header class="pos-header">
-      <h1 class="text-lg md:text-xl font-bold">Punto de Venta</h1>
+      <h1 class="text-lg md:text-xl font-bold inline-flex items-center gap-2">
+        <ShoppingCart class="w-5 h-5" aria-hidden="true" />
+        Punto de Venta
+      </h1>
       <div class="flex gap-2">
-        <router-link to="/Products" class="btn btn-indigo px-3 py-2 text-xs sm:text-sm">
+        <router-link to="/Products" class="btn btn-indigo px-3 py-2 text-xs sm:text-sm inline-flex items-center gap-2">
+          <Boxes class="w-4 h-4" aria-hidden="true" />
           Inventario
         </router-link>
-        <router-link to="/Menu" class="btn btn-dark px-3 py-2 text-xs sm:text-sm">
+        <router-link to="/Menu" class="btn btn-dark px-3 py-2 text-xs sm:text-sm inline-flex items-center gap-2">
+          <Home class="w-4 h-4" aria-hidden="true" />
           Salir
         </router-link>
       </div>
@@ -96,10 +101,14 @@
         <!-- Ticket header -->
         <div class="pos-ticket-header">
           <h3 class="font-bold flex items-center gap-2" style="color: var(--color-text);">
+            <Receipt class="w-4 h-4" aria-hidden="true" />
             Ticket
             <span class="badge badge-blue text-xs px-2 py-0.5 rounded-full">{{ cart.length }} items</span>
           </h3>
-          <button @click="cart = []" v-if="cart.length > 0" class="text-xs text-red-400 hover:text-red-300 hover:underline cursor-pointer">Vaciar</button>
+          <button @click="cart = []" v-if="cart.length > 0" class="text-xs text-red-400 hover:text-red-300 hover:underline cursor-pointer inline-flex items-center gap-1">
+            <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
+            Vaciar
+          </button>
         </div>
 
         <!-- Ticket items -->
@@ -118,7 +127,9 @@
             </div>
             <div class="flex items-center gap-3">
               <span class="font-bold" style="color: var(--color-text-soft);">${{ formatCurrency(item.price * item.quantity) }}</span>
-              <button @click="removeFromCart(index)" class="pos-remove-btn">×</button>
+              <button @click="removeFromCart(index)" class="pos-remove-btn" aria-label="Quitar del carrito">
+                <X class="w-4 h-4" aria-hidden="true" />
+              </button>
             </div>
           </div>
         </div>
@@ -133,10 +144,16 @@
           <button
             @click="procesarVenta"
             :disabled="cart.length === 0 || !selectedMemberId"
-            class="pos-cobrar-btn"
+            class="pos-cobrar-btn inline-flex items-center justify-center gap-2"
           >
-            <template v-if="!selectedMemberId">Selecciona Cliente</template>
-            <template v-else>COBRAR</template>
+            <template v-if="!selectedMemberId">
+              <UserCircle class="w-5 h-5" aria-hidden="true" />
+              Selecciona Cliente
+            </template>
+            <template v-else>
+              <CreditCard class="w-5 h-5" aria-hidden="true" />
+              COBRAR
+            </template>
           </button>
         </div>
       </div>
@@ -149,7 +166,7 @@
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
 
 import api from '@/axios'
-import { ChevronDown, Search, ShoppingCart, X } from 'lucide-vue-next'
+import { ChevronDown, Search, ShoppingCart, X, Boxes, Home, Receipt, Trash2, UserCircle, CreditCard } from 'lucide-vue-next'
 import Swal from 'sweetalert2'
 import dayjs from 'dayjs'
 

--- a/src/views/POS.vue
+++ b/src/views/POS.vue
@@ -27,41 +27,14 @@
 
         <!-- Barra de filtros -->
         <div class="pos-filters">
-          <div class="flex-1 relative client-select-wrap" ref="clientSelectRef">
-            <input
-              type="text"
-              v-model="clientSearchText"
-              @focus="isClientDropdownOpen = true"
-              @input="isClientDropdownOpen = true; selectedMemberId = ''"
-              class="pos-client-select w-full"
+          <div class="flex-1">
+            <BaseSelect
+              v-model="selectedMemberId"
+              :options="memberOptions"
               placeholder="Seleccionar Cliente"
+              searchable
+              empty-text="No se encontraron clientes"
             />
-            <button
-              v-if="clientSearchText"
-              @click.stop="clearClientSelection"
-              class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 hover:text-red-500 transition-colors flex items-center justify-center cursor-pointer z-10"
-              title="Borrar selección"
-            >
-              <X class="w-5 h-5" aria-hidden="true" />
-            </button>
-            <ChevronDown v-else class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 pointer-events-none" aria-hidden="true" />
-            <ul v-if="isClientDropdownOpen" class="absolute z-50 w-full mt-1 bg-white dark:bg-[#1f2937] border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
-              <li
-                v-if="filteredClientOptions.length === 0"
-                class="px-4 py-3 text-sm text-gray-500 dark:text-gray-400"
-              >
-                No se encontraron clientes
-              </li>
-              <li
-                v-for="member in filteredClientOptions"
-                :key="member.id"
-                @click="selectMember(member)"
-                class="px-4 py-2.5 text-sm cursor-pointer hover:bg-blue-50 dark:hover:bg-blue-900/30 text-gray-700 dark:text-gray-200 transition-colors"
-                :class="{ 'bg-blue-50 dark:bg-blue-900/40 text-blue-600 dark:text-blue-400 font-semibold': selectedMemberId === member.id }"
-              >
-                {{ member.name }}
-              </li>
-            </ul>
           </div>
           <div class="flex-1 relative search-input-wrap">
             <div class="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none text-gray-400 dark:text-gray-500">
@@ -163,10 +136,11 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 
 import api from '@/axios'
-import { ChevronDown, Search, ShoppingCart, X, Boxes, Home, Receipt, Trash2, UserCircle, CreditCard } from 'lucide-vue-next'
+import { Search, ShoppingCart, X, Boxes, Home, Receipt, Trash2, UserCircle, CreditCard } from 'lucide-vue-next'
+import { BaseSelect } from '@/components/ui'
 import Swal from 'sweetalert2'
 import dayjs from 'dayjs'
 
@@ -176,35 +150,9 @@ const cart = ref([])
 const search = ref('')
 const selectedMemberId = ref('')
 
-const clientSearchText = ref('')
-const isClientDropdownOpen = ref(false)
-const clientSelectRef = ref(null)
-
-const filteredClientOptions = computed(() => {
-  if (!clientSearchText.value) return members.value
-  const lower = clientSearchText.value.toLowerCase()
-  return members.value.filter(m => m.name.toLowerCase().includes(lower))
-})
-
-const selectMember = (member) => {
-  selectedMemberId.value = member.id
-  clientSearchText.value = member.name
-  isClientDropdownOpen.value = false
-}
-
-const clearClientSelection = () => {
-  selectedMemberId.value = ''
-  clientSearchText.value = ''
-  isClientDropdownOpen.value = false
-}
-
-const handleClickOutside = (e) => {
-  if (clientSelectRef.value && !clientSelectRef.value.contains(e.target)) {
-    isClientDropdownOpen.value = false
-    const m = members.value.find(x => x.id === selectedMemberId.value)
-    clientSearchText.value = m ? m.name : ''
-  }
-}
+const memberOptions = computed(() =>
+  members.value.map((m) => ({ value: m.id, label: m.name }))
+)
 
 const fetchData = async () => {
   try {
@@ -281,7 +229,6 @@ const procesarVenta = async () => {
 
     cart.value = []
     selectedMemberId.value = ''
-    clientSearchText.value = ''
     fetchData()
   } catch (error) {
     console.error(error)
@@ -291,11 +238,6 @@ const procesarVenta = async () => {
 
 onMounted(() => {
   fetchData()
-  document.addEventListener('click', handleClickOutside)
-})
-
-onUnmounted(() => {
-  document.removeEventListener('click', handleClickOutside)
 })
 </script>
 
@@ -373,62 +315,6 @@ onUnmounted(() => {
 /* ═══════════════════════════════════════════
    Estilos Premium para los Inputs de Filtro
    ═══════════════════════════════════════════ */
-.client-select-wrap input {
-  height: 3rem;
-  font-weight: 600;
-  border: 1.5px solid rgba(59, 130, 246, 0.3);
-  background: rgba(59, 130, 246, 0.04);
-  color: var(--color-text);
-  border-radius: 0.75rem;
-  transition: all 0.3s ease;
-  font-size: 0.95rem;
-  padding-left: 1rem;
-  padding-right: 2.5rem;
-  outline: none;
-}
-.client-select-wrap input::placeholder {
-  color: var(--color-text);
-  opacity: 0.85;
-}
-.client-select-wrap input:hover {
-  background: rgba(59, 130, 246, 0.08);
-  border-color: rgba(59, 130, 246, 0.5);
-}
-.client-select-wrap input:focus {
-  border-color: #3b82f6;
-  background: var(--color-surface);
-  box-shadow: 0 0 0 4px rgba(59, 130, 246, 0.15);
-}
-:global(.dark) .client-select-wrap input {
-  background: rgba(96, 165, 250, 0.08);
-  border-color: rgba(96, 165, 250, 0.25);
-  color: #93c5fd;
-}
-:global(.dark) .client-select-wrap input::placeholder {
-  color: rgba(147, 197, 253, 0.7);
-}
-:global(.dark) .client-select-wrap input:hover {
-  background: rgba(96, 165, 250, 0.12);
-  border-color: rgba(96, 165, 250, 0.4);
-}
-:global(.dark) .client-select-wrap input:focus {
-  background: var(--color-surface);
-  border-color: #60a5fa;
-  box-shadow: 0 0 0 4px rgba(96, 165, 250, 0.2);
-}
-
-/* Custom Scrollbar for dropdown */
-.client-select-wrap ul::-webkit-scrollbar {
-  width: 6px;
-}
-.client-select-wrap ul::-webkit-scrollbar-track {
-  background: transparent;
-}
-.client-select-wrap ul::-webkit-scrollbar-thumb {
-  background: rgba(156, 163, 175, 0.5);
-  border-radius: 4px;
-}
-
 .search-input-wrap .pos-search-input {
   padding-left: 2.75rem;
   height: 3rem;

--- a/src/views/POS.vue
+++ b/src/views/POS.vue
@@ -37,11 +37,9 @@
               class="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-400 hover:text-red-500 transition-colors flex items-center justify-center cursor-pointer z-10"
               title="Borrar selección"
             >
-              <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
+              ✕
             </button>
-            <svg v-else class="absolute right-3 top-1/2 -translate-y-1/2 w-4 h-4 text-gray-400 pointer-events-none" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M19 9l-7 7-7-7" /></svg>
+            <span v-else class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none">&#8964;</span>
             <ul v-if="isClientDropdownOpen" class="absolute z-50 w-full mt-1 bg-white dark:bg-[#1f2937] border border-gray-200 dark:border-gray-700 rounded-lg shadow-lg max-h-60 overflow-y-auto">
               <li
                 v-if="filteredClientOptions.length === 0"
@@ -62,7 +60,7 @@
           </div>
           <div class="flex-1 relative search-input-wrap">
             <div class="absolute inset-y-0 left-0 flex items-center pl-3.5 pointer-events-none text-gray-400 dark:text-gray-500">
-              <svg class="w-5 h-5" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"></path></svg>
+              
             </div>
             <input v-model="search" type="text" placeholder="Buscar producto por nombre..." class="field-input text-sm pos-search-input">
           </div>
@@ -98,7 +96,7 @@
         <!-- Ticket header -->
         <div class="pos-ticket-header">
           <h3 class="font-bold flex items-center gap-2" style="color: var(--color-text);">
-            🧾 Ticket
+            Ticket
             <span class="badge badge-blue text-xs px-2 py-0.5 rounded-full">{{ cart.length }} items</span>
           </h3>
           <button @click="cart = []" v-if="cart.length > 0" class="text-xs text-red-400 hover:text-red-300 hover:underline cursor-pointer">Vaciar</button>
@@ -107,7 +105,7 @@
         <!-- Ticket items -->
         <div class="pos-ticket-items">
           <div v-if="cart.length === 0" class="h-full flex flex-col items-center justify-center opacity-40">
-            <svg class="w-10 h-10 mb-2" style="color: var(--color-text-subtle);" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437M7.5 14.25a3 3 0 00-3 3h15.75m-12.75-3h11.218c1.121-2.3 2.1-4.684 2.924-7.138a60.114 60.114 0 00-16.536-1.84M7.5 14.25L5.106 5.272M6 20.25a.75.75 0 11-1.5 0 .75.75 0 011.5 0zm12.75 0a.75.75 0 11-1.5 0 .75.75 0 011.5 0z"/></svg>
+            
             <p class="text-sm" style="color: var(--color-text-subtle);">Carrito vacío</p>
           </div>
 
@@ -149,6 +147,7 @@
 
 <script setup>
 import { ref, computed, onMounted, onUnmounted, watch } from 'vue'
+
 import api from '@/axios'
 import Swal from 'sweetalert2'
 import dayjs from 'dayjs'

--- a/src/views/Payments.vue
+++ b/src/views/Payments.vue
@@ -9,8 +9,14 @@
           <p class="page-subtitle">Consulta y registra pagos</p>
         </div>
         <div class="flex flex-wrap gap-2 w-full sm:w-auto">
-          <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none">Inicio</router-link>
-          <button @click="openModal = true" class="btn btn-success flex-1 sm:flex-none">Registrar pago</button>
+          <router-link to="/Menu" class="btn btn-secondary flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <Home class="w-4 h-4" aria-hidden="true" />
+            <span>Inicio</span>
+          </router-link>
+          <button @click="openModal = true" class="btn btn-success flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <Plus class="w-4 h-4" aria-hidden="true" />
+            <span>Registrar pago</span>
+          </button>
         </div>
       </div>
 
@@ -36,10 +42,12 @@
 
         <button
           @click="cargarHistorial"
-          class="btn btn-primary w-full sm:w-auto justify-center"
+          class="btn btn-primary w-full sm:w-auto justify-center inline-flex items-center gap-2"
           :disabled="loadingHistorial"
         >
-          {{ loadingHistorial ? 'Cargando...' : 'Consultar' }}
+          <Loader2 v-if="loadingHistorial" class="w-4 h-4 animate-spin" aria-hidden="true" />
+          <Search v-else class="w-4 h-4" aria-hidden="true" />
+          <span>{{ loadingHistorial ? 'Cargando...' : 'Consultar' }}</span>
         </button>
       </div>
 
@@ -97,12 +105,14 @@
         <span>Página {{ currentPagePagos }} de {{ totalPagesPagos }}</span>
         <div class="flex gap-1">
           <button @click="currentPagePagos--" :disabled="currentPagePagos === 1"
-            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed">
-            ← Anterior
+            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1">
+            <ChevronLeft class="w-4 h-4" aria-hidden="true" />
+            <span>Anterior</span>
           </button>
           <button @click="currentPagePagos++" :disabled="currentPagePagos === totalPagesPagos"
-            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed">
-            Siguiente →
+            class="px-3 py-1 rounded border border-default-soft bg-[var(--color-surface)] hover:bg-[var(--color-surface-soft)] disabled:opacity-40 disabled:cursor-not-allowed inline-flex items-center gap-1">
+            <span>Siguiente</span>
+            <ChevronRight class="w-4 h-4" aria-hidden="true" />
           </button>
         </div>
       </div>
@@ -117,6 +127,7 @@
           :style="{ background: 'var(--modal-panel-bg)', border: '1px solid var(--modal-panel-border)' }"
         >
           <h2 id="payments-modal-title" class="text-lg font-bold mb-4 text-default border-b border-default-soft pb-2 flex items-center gap-2">
+            <CreditCard class="w-5 h-5" aria-hidden="true" />
             Registrar Pago
           </h2>
 
@@ -174,13 +185,16 @@
               <button
                 type="button"
                 @click="cerrarModal"
-                class="btn btn-secondary flex-1"
+                class="btn btn-secondary flex-1 inline-flex items-center justify-center gap-2"
                 :disabled="ProcesandoPago"
               >
-                Cancelar
+                <X class="w-4 h-4" aria-hidden="true" />
+                <span>Cancelar</span>
               </button>
-              <button type="submit" class="btn btn-primary flex-1" :disabled="ProcesandoPago">
-                {{ ProcesandoPago ? "Guardando..." : "Guardar" }}
+              <button type="submit" class="btn btn-primary flex-1 inline-flex items-center justify-center gap-2" :disabled="ProcesandoPago">
+                <Loader2 v-if="ProcesandoPago" class="w-4 h-4 animate-spin" aria-hidden="true" />
+                <Check v-else class="w-4 h-4" aria-hidden="true" />
+                <span>{{ ProcesandoPago ? "Guardando..." : "Guardar" }}</span>
               </button>
             </div>
           </form>
@@ -196,6 +210,17 @@ import { ref, computed, onMounted } from "vue";
 import api from "@/axios";
 import dayjs from "dayjs";
 import Swal from "sweetalert2";
+import {
+  Home,
+  Plus,
+  Search,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  CreditCard,
+  X,
+  Check,
+} from "lucide-vue-next";
 // --- ESTADO ---
 const pagos = ref([]);
 const currentPagePagos = ref(1);

--- a/src/views/Payments.vue
+++ b/src/views/Payments.vue
@@ -39,7 +39,7 @@
           class="btn btn-primary w-full sm:w-auto justify-center"
           :disabled="loadingHistorial"
         >
-          {{ loadingHistorial ? "⏳" : "🔍 Consultar" }}
+          {{ loadingHistorial ? 'Cargando...' : 'Consultar' }}
         </button>
       </div>
 
@@ -47,7 +47,7 @@
         class="p-4 mb-6 rounded-r-xl shadow-sm flex flex-col sm:flex-row justify-between items-center gap-2 text-center sm:text-left border-l-4"
         style="background: var(--color-surface-soft); border-color: #10b981; border-top: 1px solid var(--color-border); border-right: 1px solid var(--color-border); border-bottom: 1px solid var(--color-border);"
       >
-        <span class="text-sm sm:text-lg font-semibold" style="color: var(--color-text-muted);">💰 Total en rango:</span>
+        <span class="text-sm sm:text-lg font-semibold" style="color: var(--color-text-muted);">Total en rango:</span>
         <span
           class="text-xl sm:text-2xl font-bold px-4 py-1 rounded shadow-sm w-full sm:w-auto"
           style="background: var(--color-surface); border: 1px solid var(--color-border); color: #10b981;"
@@ -180,7 +180,7 @@
                 Cancelar
               </button>
               <button type="submit" class="btn btn-primary flex-1" :disabled="ProcesandoPago">
-                {{ ProcesandoPago ? "💾..." : "Guardar" }}
+                {{ ProcesandoPago ? "Guardando..." : "Guardar" }}
               </button>
             </div>
           </form>
@@ -192,6 +192,7 @@
 
 <script setup>
 import { ref, computed, onMounted } from "vue";
+
 import api from "@/axios";
 import dayjs from "dayjs";
 import Swal from "sweetalert2";

--- a/src/views/Payments.vue
+++ b/src/views/Payments.vue
@@ -171,14 +171,12 @@
 
             <div>
               <label class="block mb-1 text-xs font-bold text-muted uppercase">Método</label>
-              <select
+              <BaseSelect
                 v-model="nuevoPago.payment_method_id"
+                placeholder="Seleccionar..."
                 required
-                class="field-input"
-              >
-                <option disabled value="">Seleccionar...</option>
-                <option v-for="m in metodosPago" :key="m.id" :value="m.id">{{ m.name }}</option>
-              </select>
+                :options="metodoPagoOptions"
+              />
             </div>
 
             <div class="flex justify-end gap-2 pt-4 border-t mt-2">
@@ -221,6 +219,7 @@ import {
   X,
   Check,
 } from "lucide-vue-next";
+import { BaseSelect } from "@/components/ui";
 // --- ESTADO ---
 const pagos = ref([]);
 const currentPagePagos = ref(1);
@@ -244,6 +243,10 @@ const filtros = ref({
 });
 
 const nuevoPago = ref({ member_id: "", amount: "", payment_method_id: "" });
+
+const metodoPagoOptions = computed(() =>
+  metodosPago.value.map((m) => ({ value: m.id, label: m.name }))
+);
 
 // --- FUNCIONES ---
 const cargarHistorial = async () => {

--- a/src/views/Products.vue
+++ b/src/views/Products.vue
@@ -7,19 +7,25 @@
           <p class="page-subtitle">Gestión de productos y stock</p>
         </div>
         <div class="flex flex-wrap gap-2 w-full sm:w-auto">
-          <router-link to="/Menu" class="btn btn-dark flex-1 sm:flex-none">
-            Inicio
+          <router-link to="/Menu" class="btn btn-dark flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <Home class="w-4 h-4" aria-hidden="true" />
+            <span>Inicio</span>
           </router-link>
           <BaseButton variant="success" class="flex-1 sm:flex-none" @click="abrirModalRegistro">
+            <Plus class="w-4 h-4" aria-hidden="true" />
             Agregar producto
           </BaseButton>
-          <router-link to="/inventory-log" class="btn btn-secondary flex-1 sm:flex-none">
-            Movimientos
+          <router-link to="/inventory-log" class="btn btn-secondary flex-1 sm:flex-none inline-flex items-center justify-center gap-2">
+            <ClipboardList class="w-4 h-4" aria-hidden="true" />
+            <span>Movimientos</span>
           </router-link>
         </div>
       </header>
 
-      <BaseInput v-model="busqueda" placeholder="Buscar producto..." />
+      <div class="relative">
+        <Search class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none z-10" aria-hidden="true" />
+        <BaseInput v-model="busqueda" placeholder="Buscar producto..." class="pl-10" />
+      </div>
 
       <div v-if="loading" class="text-subtle text-center py-10">Cargando...</div>
 
@@ -63,6 +69,7 @@
                 class="flex-1 justify-center"
                 @click="editarProducto(producto)"
               >
+                <Pencil class="w-3.5 h-3.5" aria-hidden="true" />
                 Editar
               </BaseButton>
               <BaseButton
@@ -71,6 +78,7 @@
                 class="flex-1 justify-center"
                 @click="eliminarProducto(producto.id)"
               >
+                <Trash2 class="w-3.5 h-3.5" aria-hidden="true" />
                 Eliminar
               </BaseButton>
             </div>
@@ -89,6 +97,7 @@
               :disabled="currentPageProductos === 1"
               @click="currentPageProductos--"
             >
+              <ChevronLeft class="w-4 h-4" aria-hidden="true" />
               Anterior
             </BaseButton>
             <BaseButton
@@ -98,6 +107,7 @@
               @click="currentPageProductos++"
             >
               Siguiente
+              <ChevronRight class="w-4 h-4" aria-hidden="true" />
             </BaseButton>
           </div>
         </div>
@@ -149,9 +159,11 @@
 
       <template #footer>
         <BaseButton variant="secondary" @click="cerrarModalRegistro">
+          <X class="w-4 h-4" aria-hidden="true" />
           Cancelar
         </BaseButton>
         <BaseButton variant="primary" type="submit" form="product-form">
+          <Check class="w-4 h-4" aria-hidden="true" />
           Guardar
         </BaseButton>
       </template>
@@ -165,6 +177,18 @@ import api from "@/axios";
 import Swal from "sweetalert2";
 import { BaseButton, BaseInput, BaseBadge, BaseModal } from "@/components/ui";
 import { SWAL_COLORS } from "@/lib/colors";
+import {
+  Home,
+  Plus,
+  Search,
+  Pencil,
+  Trash2,
+  ChevronLeft,
+  ChevronRight,
+  ClipboardList,
+  X,
+  Check,
+} from "lucide-vue-next";
 const productos = ref([]);
 const currentPageProductos = ref(1);
 const PER_PAGE = 10;

--- a/src/views/PublicRegister.vue
+++ b/src/views/PublicRegister.vue
@@ -15,15 +15,20 @@
 
         <!-- Estado de éxito -->
         <div v-if="successMessage" class="text-center p-4 bg-green-100 text-green-700 rounded-lg">
+          <CheckCircle2 class="w-12 h-12 mx-auto mb-2 text-green-600" aria-hidden="true" />
           <h2 class="text-2xl font-bold mb-2">¡Registro Exitoso!</h2>
           <p>{{ successMessage }}</p>
         </div>
 
         <!-- Estado de carga o formulario -->
         <div v-else>
-          <h2 class="text-2xl font-bold mb-6 text-center text-default">Formulario de Inscripción</h2>
+          <h2 class="text-2xl font-bold mb-6 text-center text-default flex items-center justify-center gap-2">
+            <UserPlus class="w-6 h-6" aria-hidden="true" />
+            Formulario de Inscripción
+          </h2>
 
-          <div v-if="loading" class="text-center text-muted">
+          <div v-if="loading" class="text-center text-muted flex items-center justify-center gap-2">
+            <Loader2 class="w-5 h-5 animate-spin" aria-hidden="true" />
             Cargando planes...
           </div>
 
@@ -31,33 +36,51 @@
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-muted text-sm mb-1">Nombre Completo</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <User class="w-3 h-3" aria-hidden="true" />
+                  Nombre Completo
+                </label>
                 <input v-model="form.name" type="text" class="input-field" required />
               </div>
               <div>
-                <label class="block text-muted text-sm mb-1">Identificación (Cédula)</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <IdCard class="w-3 h-3" aria-hidden="true" />
+                  Identificación (Cédula)
+                </label>
                 <input v-model="form.identification" type="text" class="input-field" required />
               </div>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-muted text-sm mb-1">Correo</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <Mail class="w-3 h-3" aria-hidden="true" />
+                  Correo
+                </label>
                 <input v-model="form.email" type="email" class="input-field" required/>
               </div>
               <div>
-                <label class="block text-muted text-sm mb-1">Teléfono</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <Phone class="w-3 h-3" aria-hidden="true" />
+                  Teléfono
+                </label>
                 <input v-model="form.phone" type="tel" class="input-field" required/>
               </div>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-muted text-sm mb-1">Fecha de Nacimiento</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <Calendar class="w-3 h-3" aria-hidden="true" />
+                  Fecha de Nacimiento
+                </label>
                 <input v-model="form.birth_date" type="date" class="input-field" required />
               </div>
               <div>
-                <label class="block text-muted text-sm mb-1">Sexo</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <Users class="w-3 h-3" aria-hidden="true" />
+                  Sexo
+                </label>
                 <BaseSelect
                   v-model="form.sexo"
                   placeholder="Seleccione..."
@@ -69,11 +92,17 @@
 
             <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div>
-                <label class="block text-muted text-sm mb-1">Peso (kg)</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <Scale class="w-3 h-3" aria-hidden="true" />
+                  Peso (kg)
+                </label>
                 <input v-model.number="form.peso" type="number" step="0.1" class="input-field" placeholder="Ej. 70.5" />
               </div>
               <div>
-                <label class="block text-muted text-sm mb-1">Estatura (m)</label>
+                <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                  <Ruler class="w-3 h-3" aria-hidden="true" />
+                  Estatura (m)
+                </label>
                 <input v-model.number="form.estatura" type="number" step="0.01" class="input-field" placeholder="Ej. 1.75" />
               </div>
             </div>
@@ -81,7 +110,10 @@
             <!-- CAMPO 'OBJETIVO' ELIMINADO -->
 
             <div>
-              <label class="block text-muted text-sm mb-1">Plan de Membresía</label>
+              <label class="block text-muted text-sm mb-1 flex items-center gap-1">
+                <CalendarCheck2 class="w-3 h-3" aria-hidden="true" />
+                Plan de Membresía
+              </label>
               <BaseSelect
                 v-model="form.plan_id"
                 placeholder="Seleccione el plan que desea"
@@ -95,16 +127,19 @@
               />
             </div>
 
-            <div v-if="errorMessage" class="text-red-600 text-sm text-center">
+            <div v-if="errorMessage" class="text-red-600 text-sm text-center flex items-center justify-center gap-1">
+              <AlertCircle class="w-4 h-4" aria-hidden="true" />
               {{ errorMessage }}
             </div>
 
             <button
               type="submit"
-              class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 rounded-lg transition duration-200"
+              class="w-full bg-blue-600 hover:bg-blue-700 text-white font-bold py-3 rounded-lg transition duration-200 inline-flex items-center justify-center gap-2"
               :disabled="loading"
             >
-              {{ loading ? 'Registrando...' : 'Inscribirme' }}
+              <Loader2 v-if="loading" class="w-4 h-4 animate-spin" aria-hidden="true" />
+              <UserPlus v-else class="w-4 h-4" aria-hidden="true" />
+              <span>{{ loading ? 'Registrando...' : 'Inscribirme' }}</span>
             </button>
           </form>
         </div>
@@ -132,6 +167,21 @@ import { ref, reactive, onMounted } from 'vue'
 import { useRoute } from 'vue-router'
 import api from '@/axios' // Usamos la instancia de Axios
 import { BaseSelect } from '@/components/ui'
+import {
+  User,
+  IdCard,
+  Mail,
+  Phone,
+  Calendar,
+  Users,
+  Scale,
+  Ruler,
+  CalendarCheck2,
+  AlertCircle,
+  CheckCircle2,
+  Loader2,
+  UserPlus,
+} from 'lucide-vue-next'
 
 const SEXO_OPTIONS = [
   { value: 'masculino', label: 'Masculino' },

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -24,9 +24,6 @@
         <div class="auth-field">
           <label class="login-label">Nombre completo</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 6a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0zM4.501 20.118a7.5 7.5 0 0114.998 0A17.933 17.933 0 0112 21.75c-2.676 0-5.216-.584-7.499-1.632z" />
-            </svg>
             <input v-model="form.name" type="text" class="login-input" placeholder="Tu nombre completo" required />
           </div>
         </div>
@@ -34,9 +31,6 @@
         <div class="auth-field">
           <label class="login-label">Correo electrónico</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75" />
-            </svg>
             <input v-model="form.email" type="email" class="login-input" placeholder="tu@correo.com" required />
           </div>
         </div>
@@ -44,9 +38,6 @@
         <div class="auth-field">
           <label class="login-label">Nombre del Gimnasio</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M2.25 21h19.5m-18-18v18m10.5-18v18m6-13.5V21M6.75 6.75h.75m-.75 3h.75m-.75 3h.75m3-6h.75m-.75 3h.75m-.75 3h.75M6.75 21v-3.375c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21M3 3h12m-.75 4.5H21m-3.75 3.75h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008zm0 3h.008v.008h-.008v-.008z" />
-            </svg>
             <input v-model="form.gym_name" type="text" class="login-input" placeholder="Nombre de tu gimnasio" required />
           </div>
         </div>
@@ -54,18 +45,9 @@
         <div class="auth-field">
           <label class="login-label">Contraseña</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 10.5V6.75a4.5 4.5 0 10-9 0v3.75m-.75 11.25h10.5a2.25 2.25 0 002.25-2.25v-6.75a2.25 2.25 0 00-2.25-2.25H6.75a2.25 2.25 0 00-2.25 2.25v6.75a2.25 2.25 0 002.25 2.25z" />
-            </svg>
             <input v-model="form.password" :type="showPassword ? 'text' : 'password'" class="login-input pr-11" placeholder="••••••••" required />
             <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
-              <svg v-if="!showPassword" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z" />
-                <path stroke-linecap="round" stroke-linejoin="round" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
-              </svg>
-              <svg v-else xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
-                <path stroke-linecap="round" stroke-linejoin="round" d="M3.98 8.223A10.477 10.477 0 001.934 12C3.226 16.338 7.244 19.5 12 19.5c.993 0 1.953-.138 2.863-.395M6.228 6.228A10.45 10.45 0 0112 4.5c4.756 0 8.773 3.162 10.065 7.498a10.523 10.523 0 01-4.293 5.774M6.228 6.228L3 3m3.228 3.228l3.65 3.65m7.894 7.894L21 21m-3.228-3.228l-3.65-3.65m0 0a3 3 0 10-4.243-4.243m4.242 4.242L9.88 9.88" />
-              </svg>
+              {{ showPassword ? 'Ocultar' : 'Ver' }}
             </button>
           </div>
         </div>
@@ -73,19 +55,12 @@
         <div class="auth-field">
           <label class="login-label">Confirmar contraseña</label>
           <div class="auth-input-wrap">
-            <svg class="login-input-icon" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
-              <path stroke-linecap="round" stroke-linejoin="round" d="M9 12.75L11.25 15 15 9.75m-3-7.036A11.959 11.959 0 013.598 6 11.99 11.99 0 003 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285z" />
-            </svg>
             <input v-model="form.password_confirmation" :type="showPassword ? 'text' : 'password'" class="login-input" placeholder="••••••••" required />
           </div>
         </div>
 
         <div class="pt-2">
           <button type="submit" :disabled="loading" class="auth-submit-btn">
-            <svg v-if="loading" class="animate-spin mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-              <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-              <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-            </svg>
             {{ loading ? 'Creando cuenta...' : 'Crear Cuenta' }}
           </button>
         </div>
@@ -102,6 +77,7 @@
 
 <script setup lang="ts">
 import { ref, reactive } from 'vue'
+
 import { useRouter } from 'vue-router'
 import api from '@/axios'
 import { useAuthStore } from '@/stores/useAuthStore'

--- a/src/views/Register.vue
+++ b/src/views/Register.vue
@@ -23,45 +23,52 @@
 
         <div class="auth-field">
           <label class="login-label">Nombre completo</label>
-          <div class="auth-input-wrap">
-            <input v-model="form.name" type="text" class="login-input" placeholder="Tu nombre completo" required />
+          <div class="auth-input-wrap relative">
+            <User class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="form.name" type="text" class="login-input pl-10" placeholder="Tu nombre completo" required />
           </div>
         </div>
 
         <div class="auth-field">
           <label class="login-label">Correo electrónico</label>
-          <div class="auth-input-wrap">
-            <input v-model="form.email" type="email" class="login-input" placeholder="tu@correo.com" required />
+          <div class="auth-input-wrap relative">
+            <Mail class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="form.email" type="email" class="login-input pl-10" placeholder="tu@correo.com" required />
           </div>
         </div>
 
         <div class="auth-field">
           <label class="login-label">Nombre del Gimnasio</label>
-          <div class="auth-input-wrap">
-            <input v-model="form.gym_name" type="text" class="login-input" placeholder="Nombre de tu gimnasio" required />
+          <div class="auth-input-wrap relative">
+            <Dumbbell class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="form.gym_name" type="text" class="login-input pl-10" placeholder="Nombre de tu gimnasio" required />
           </div>
         </div>
 
         <div class="auth-field">
           <label class="login-label">Contraseña</label>
-          <div class="auth-input-wrap">
-            <input v-model="form.password" :type="showPassword ? 'text' : 'password'" class="login-input pr-11" placeholder="••••••••" required />
-            <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1">
-              {{ showPassword ? 'Ocultar' : 'Ver' }}
+          <div class="auth-input-wrap relative">
+            <Lock class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="form.password" :type="showPassword ? 'text' : 'password'" class="login-input pl-10 pr-11" placeholder="••••••••" required />
+            <button type="button" class="login-eye-btn" @click="showPassword = !showPassword" tabindex="-1" :aria-label="showPassword ? 'Ocultar contraseña' : 'Mostrar contraseña'">
+              <component :is="showPassword ? EyeOff : Eye" class="w-4 h-4" aria-hidden="true" />
             </button>
           </div>
         </div>
 
         <div class="auth-field">
           <label class="login-label">Confirmar contraseña</label>
-          <div class="auth-input-wrap">
-            <input v-model="form.password_confirmation" :type="showPassword ? 'text' : 'password'" class="login-input" placeholder="••••••••" required />
+          <div class="auth-input-wrap relative">
+            <Lock class="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-muted pointer-events-none" aria-hidden="true" />
+            <input v-model="form.password_confirmation" :type="showPassword ? 'text' : 'password'" class="login-input pl-10" placeholder="••••••••" required />
           </div>
         </div>
 
         <div class="pt-2">
-          <button type="submit" :disabled="loading" class="auth-submit-btn">
-            {{ loading ? 'Creando cuenta...' : 'Crear Cuenta' }}
+          <button type="submit" :disabled="loading" class="auth-submit-btn inline-flex items-center justify-center gap-2">
+            <Loader2 v-if="loading" class="w-4 h-4 animate-spin" aria-hidden="true" />
+            <UserPlus v-else class="w-4 h-4" aria-hidden="true" />
+            <span>{{ loading ? 'Creando cuenta...' : 'Crear Cuenta' }}</span>
           </button>
         </div>
       </form>
@@ -82,6 +89,7 @@ import { useRouter } from 'vue-router'
 import api from '@/axios'
 import { useAuthStore } from '@/stores/useAuthStore'
 import Swal from 'sweetalert2'
+import { User, Mail, Lock, Dumbbell, Eye, EyeOff, Loader2, UserPlus } from 'lucide-vue-next'
 
 const router = useRouter()
 const auth = useAuthStore()

--- a/src/views/RegisterMember.vue
+++ b/src/views/RegisterMember.vue
@@ -20,7 +20,7 @@
           class="p-2 hover:bg-[var(--color-overlay)] rounded-full transition-colors"
           aria-label="Cerrar"
         >
-          ✕
+          <X class="w-5 h-5 text-muted" aria-hidden="true" />
         </router-link>
       </div>
 
@@ -283,6 +283,7 @@
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import api from "@/axios";
+import { X } from 'lucide-vue-next'
 import Swal from "sweetalert2";
 import dayjs from "dayjs";
 import FingerprintEnroll from "@/components/FingerprintEnroll.vue";

--- a/src/views/RegisterMember.vue
+++ b/src/views/RegisterMember.vue
@@ -6,6 +6,12 @@
       <!-- Header -->
       <div class="flex items-center justify-between px-6 sm:px-8 py-5 border-b border-default-soft">
         <div class="flex items-center gap-4">
+          <div
+            class="w-11 h-11 rounded-xl flex items-center justify-center shrink-0"
+            style="background: rgba(99,102,241,0.12); color: #818cf8;"
+          >
+            <UserPlus class="w-5 h-5" aria-hidden="true" />
+          </div>
           <div>
             <h1 class="text-xl font-bold text-default tracking-tight leading-tight">
               Registrar Nuevo Cliente
@@ -262,8 +268,9 @@
       >
         <router-link
           :to="{ name: 'Members' }"
-          class="px-5 py-2.5 text-sm font-bold text-subtle hover:text-default transition-colors"
+          class="px-5 py-2.5 text-sm font-bold text-subtle hover:text-default transition-colors inline-flex items-center gap-2"
         >
+          <X class="w-4 h-4" aria-hidden="true" />
           Cancelar
         </router-link>
         <button
@@ -272,6 +279,8 @@
           class="register-submit-btn"
           @click="registerMember"
         >
+          <Loader2 v-if="saving" class="w-4 h-4 animate-spin" aria-hidden="true" />
+          <Save v-else class="w-4 h-4" aria-hidden="true" />
           <span>{{ saving ? "Guardando..." : "Guardar Cliente" }}</span>
         </button>
       </div>
@@ -283,7 +292,7 @@
 import { ref, onMounted } from "vue";
 import { useRouter } from "vue-router";
 import api from "@/axios";
-import { X } from 'lucide-vue-next'
+import { X, UserPlus, Save, Loader2 } from 'lucide-vue-next'
 import Swal from "sweetalert2";
 import dayjs from "dayjs";
 import FingerprintEnroll from "@/components/FingerprintEnroll.vue";

--- a/src/views/RegisterMember.vue
+++ b/src/views/RegisterMember.vue
@@ -20,9 +20,7 @@
           class="p-2 hover:bg-[var(--color-overlay)] rounded-full transition-colors"
           aria-label="Cerrar"
         >
-          <svg class="w-5 h-5 text-subtle" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-          </svg>
+          ✕
         </router-link>
       </div>
 
@@ -274,10 +272,6 @@
           class="register-submit-btn"
           @click="registerMember"
         >
-          <svg v-if="saving" class="w-4 h-4 animate-spin" viewBox="0 0 24 24" fill="none">
-            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v4a4 4 0 00-4 4H4z" />
-          </svg>
           <span>{{ saving ? "Guardando..." : "Guardar Cliente" }}</span>
         </button>
       </div>

--- a/src/views/Sidebar.vue
+++ b/src/views/Sidebar.vue
@@ -3,7 +3,8 @@
 <template>
   <div>
     <!-- Botón hamburguesa -->
-    <button @click="toggle" class="fixed top-4 left-4 z-50 text-white bg-blue-600 px-3 py-2 rounded shadow-lg">
+    <button @click="toggle" class="fixed top-4 left-4 z-50 text-white bg-blue-600 px-3 py-2 rounded shadow-lg inline-flex items-center gap-2">
+      <Menu class="w-4 h-4" aria-hidden="true" />
       Menú
     </button>
 
@@ -12,17 +13,36 @@
       class="fixed top-0 left-0 h-full bg-[var(--color-surface)] shadow-lg w-64 z-40 transform transition-transform duration-300 border-r border-default-soft"
       :class="{ '-translate-x-full': !open }"
     >
-      <div class="p-6 border-b border-default-soft text-lg font-bold text-blue-700 ml-16">
+      <div class="p-6 border-b border-default-soft text-lg font-bold text-blue-700 ml-16 inline-flex items-center gap-2">
+        <Dumbbell class="w-5 h-5" aria-hidden="true" />
         CosmoGym
       </div>
 
       <nav class="flex flex-col p-4 space-y-2 text-default">
-        <router-link @click="toggle" to="/Menu" class="hover:text-blue-600">Inicio</router-link>
-        <router-link @click="toggle" to="/members" class="hover:text-blue-600">Clientes</router-link>
-        <router-link @click="toggle" to="/Membership" class="hover:text-blue-600">Membresías</router-link>
-        <router-link @click="toggle" to="/payments" class="hover:text-blue-600">Pagos</router-link>
-        <router-link @click="toggle" to="/membershipPlans" class="hover:text-blue-600">Planes</router-link>
-        <router-link @click="toggle" to="/configuracion" class="hover:text-blue-600">Configuración</router-link>
+        <router-link @click="toggle" to="/Menu" class="hover:text-blue-600 inline-flex items-center gap-2">
+          <Home class="w-4 h-4" aria-hidden="true" />
+          Inicio
+        </router-link>
+        <router-link @click="toggle" to="/members" class="hover:text-blue-600 inline-flex items-center gap-2">
+          <Users class="w-4 h-4" aria-hidden="true" />
+          Clientes
+        </router-link>
+        <router-link @click="toggle" to="/Membership" class="hover:text-blue-600 inline-flex items-center gap-2">
+          <CalendarCheck2 class="w-4 h-4" aria-hidden="true" />
+          Membresías
+        </router-link>
+        <router-link @click="toggle" to="/payments" class="hover:text-blue-600 inline-flex items-center gap-2">
+          <CreditCard class="w-4 h-4" aria-hidden="true" />
+          Pagos
+        </router-link>
+        <router-link @click="toggle" to="/membershipPlans" class="hover:text-blue-600 inline-flex items-center gap-2">
+          <ClipboardList class="w-4 h-4" aria-hidden="true" />
+          Planes
+        </router-link>
+        <router-link @click="toggle" to="/configuracion" class="hover:text-blue-600 inline-flex items-center gap-2">
+          <Settings class="w-4 h-4" aria-hidden="true" />
+          Configuración
+        </router-link>
       </nav>
     </div>
   </div>
@@ -30,6 +50,16 @@
 
 <script setup>
 import { ref } from 'vue'
+import {
+  Menu,
+  Dumbbell,
+  Home,
+  Users,
+  CalendarCheck2,
+  CreditCard,
+  ClipboardList,
+  Settings,
+} from 'lucide-vue-next'
 
 const open = ref(false)
 const toggle = () => {

--- a/src/views/Statistics.vue
+++ b/src/views/Statistics.vue
@@ -3,10 +3,14 @@
     <div class="max-w-7xl mx-auto space-y-6">
       <BaseCard title="Estadísticas" subtitle="Reportes y análisis del gimnasio">
         <template #actions>
-          <router-link to="/Menu" class="btn btn-dark">Inicio</router-link>
+          <router-link to="/Menu" class="btn btn-dark inline-flex items-center justify-center gap-2">
+            <Home class="w-4 h-4" aria-hidden="true" />
+            <span>Inicio</span>
+          </router-link>
         </template>
 
-        <p v-if="loading" class="text-center py-16 text-xl text-subtle animate-pulse">
+        <p v-if="loading" class="text-center py-16 text-xl text-subtle animate-pulse flex items-center justify-center gap-2">
+          <Loader2 class="w-6 h-6 animate-spin" aria-hidden="true" />
           Cargando análisis de datos...
         </p>
       </BaseCard>
@@ -15,8 +19,13 @@
         <BaseCard
           v-for="chart in chartCards"
           :key="chart.key"
-          :title="chart.title"
         >
+          <template #header>
+            <h2 class="page-title flex items-center gap-2">
+              <component :is="chart.icon" class="w-5 h-5" aria-hidden="true" />
+              <span>{{ chart.title }}</span>
+            </h2>
+          </template>
           <div
             class="flex-1 relative min-h-[300px]"
             :class="chart.center && 'flex justify-center'"
@@ -55,6 +64,14 @@ import {
 import { Bar, Doughnut } from "vue-chartjs";
 import { CHART_COLORS } from "@/lib/colors";
 import { BaseCard } from "@/components/ui";
+import {
+  Home,
+  Loader2,
+  TrendingUp,
+  PieChart,
+  ShoppingBag,
+  Trophy,
+} from "lucide-vue-next";
 
 ChartJS.register(CategoryScale, LinearScale, BarElement, ArcElement, Title, Tooltip, Legend);
 
@@ -83,6 +100,7 @@ const chartCards = [
   {
     key: "income",
     title: "Ingresos (Últimos 7 días)",
+    icon: TrendingUp,
     component: Bar,
     data: incomeData,
     options: barOptions,
@@ -91,6 +109,7 @@ const chartCards = [
   {
     key: "pie",
     title: "Distribución de Clientes",
+    icon: PieChart,
     component: Doughnut,
     data: pieData,
     options: pieOptions,
@@ -100,6 +119,7 @@ const chartCards = [
   {
     key: "productSales",
     title: "Ventas Productos (Últimos 7 días)",
+    icon: ShoppingBag,
     component: Bar,
     data: productSalesData,
     options: barOptions,
@@ -108,6 +128,7 @@ const chartCards = [
   {
     key: "topProducts",
     title: "Top Productos Más Vendidos",
+    icon: Trophy,
     component: Bar,
     data: topProductsData,
     options: barHorizontalOptions,

--- a/src/views/Subscription.vue
+++ b/src/views/Subscription.vue
@@ -8,17 +8,24 @@
           <h1 class="text-2xl sm:text-3xl font-bold text-default tracking-tight">Suscripción</h1>
           <p class="text-sm text-subtle mt-0.5">Gestiona tu plan y funcionalidades</p>
         </div>
-        <router-link to="/Menu" class="btn btn-dark">Inicio</router-link>
+        <router-link to="/Menu" class="btn btn-dark inline-flex items-center justify-center gap-2">
+          <Home class="w-4 h-4" aria-hidden="true" />
+          <span>Inicio</span>
+        </router-link>
       </div>
 
       <div v-if="loading" class="text-center py-16">
-        <p class="text-blue-600 font-bold animate-pulse">Cargando suscripción...</p>
+        <p class="text-blue-600 font-bold animate-pulse flex items-center justify-center gap-2">
+          <Loader2 class="w-5 h-5 animate-spin" aria-hidden="true" />
+          Cargando suscripción...
+        </p>
       </div>
 
       <div v-else class="space-y-6">
 
         <!-- Sin suscripción -->
         <div v-if="!subscription" class="bg-[var(--color-surface-soft)] border border-[var(--color-border)] rounded-2xl p-6 text-center">
+          <AlertCircle class="w-10 h-10 mx-auto mb-2 text-amber-600" aria-hidden="true" />
           <p class="text-amber-700 font-semibold text-lg mb-1">No tienes una suscripción activa</p>
           <p class="text-amber-600 text-sm">Elige un plan para comenzar.</p>
         </div>
@@ -38,15 +45,24 @@
 
           <div class="grid grid-cols-2 sm:grid-cols-3 gap-4 my-6">
             <div class="bg-[var(--color-surface-soft)] rounded-xl p-4 border border-default-soft">
-              <p class="text-xs text-subtle font-semibold uppercase tracking-wide mb-1">Inicio</p>
+              <p class="text-xs text-subtle font-semibold uppercase tracking-wide mb-1 flex items-center gap-1">
+                <Calendar class="w-3 h-3" aria-hidden="true" />
+                Inicio
+              </p>
               <p class="text-sm font-bold text-default">{{ formatDate(subscription.started_at) }}</p>
             </div>
             <div class="bg-[var(--color-surface-soft)] rounded-xl p-4 border border-default-soft">
-              <p class="text-xs text-subtle font-semibold uppercase tracking-wide mb-1">Vence</p>
+              <p class="text-xs text-subtle font-semibold uppercase tracking-wide mb-1 flex items-center gap-1">
+                <CalendarX class="w-3 h-3" aria-hidden="true" />
+                Vence
+              </p>
               <p class="text-sm font-bold text-default">{{ formatDate(subscription.expired_at) }}</p>
             </div>
             <div class="bg-[var(--color-surface-soft)] rounded-xl p-4 border border-default-soft">
-              <p class="text-xs text-subtle font-semibold uppercase tracking-wide mb-1">Días restantes</p>
+              <p class="text-xs text-subtle font-semibold uppercase tracking-wide mb-1 flex items-center gap-1">
+                <Clock class="w-3 h-3" aria-hidden="true" />
+                Días restantes
+              </p>
               <p class="text-sm font-bold" :class="daysLeft <= 5 ? 'text-red-600' : 'text-emerald-600'">
                 {{ daysLeft >= 0 ? daysLeft : 0 }} días
               </p>
@@ -60,8 +76,9 @@
               <span
                 v-for="feature in subscription.plan?.features"
                 :key="feature.id"
-                class="px-3 py-1.5 bg-blue-50 text-blue-700 rounded-full text-xs font-semibold"
+                class="px-3 py-1.5 bg-blue-50 text-blue-700 rounded-full text-xs font-semibold inline-flex items-center gap-1"
               >
+                <Check class="w-3 h-3" aria-hidden="true" />
                 {{ featureLabel(feature) }}
               </span>
             </div>
@@ -69,15 +86,17 @@
 
           <!-- Acciones -->
           <div class="flex flex-col sm:flex-row gap-3 mt-6 pt-4 border-t">
-            <button @click="showPlans = true" class="btn btn-primary flex-1">
-              Cambiar plan
+            <button @click="showPlans = true" class="btn btn-primary flex-1 inline-flex items-center justify-center gap-2">
+              <RefreshCw class="w-4 h-4" aria-hidden="true" />
+              <span>Cambiar plan</span>
             </button>
             <button
               v-if="!subscription.canceled_at"
               @click="confirmCancel"
-              class="btn flex-1 border border-red-300 text-red-600 hover:bg-red-50 bg-[var(--color-surface)]"
+              class="btn flex-1 border border-red-300 text-red-600 hover:bg-red-50 bg-[var(--color-surface)] inline-flex items-center justify-center gap-2"
             >
-              Cancelar suscripción
+              <X class="w-4 h-4" aria-hidden="true" />
+              <span>Cancelar suscripción</span>
             </button>
             <div v-else class="flex-1 text-center text-sm text-subtle self-center">
               Cancelada — acceso hasta vencimiento
@@ -112,9 +131,10 @@
                 <li
                   v-for="feature in plan.features"
                   :key="feature.id"
-                  class="text-xs text-muted"
+                  class="text-xs text-muted flex items-start gap-1.5"
                 >
-                  {{ featureLabel(feature) }}
+                  <Check class="w-3 h-3 mt-0.5 text-emerald-500 flex-shrink-0" aria-hidden="true" />
+                  <span>{{ featureLabel(feature) }}</span>
                 </li>
               </ul>
 
@@ -122,11 +142,15 @@
                 v-if="subscription?.plan?.id !== plan.id"
                 @click="selectPlan(plan)"
                 :disabled="saving"
-                class="btn btn-primary text-sm py-2"
+                class="btn btn-primary text-sm py-2 inline-flex items-center justify-center gap-2"
               >
-                {{ subscription ? 'Cambiar a este' : 'Suscribirme' }}
+                <Package class="w-4 h-4" aria-hidden="true" />
+                <span>{{ subscription ? 'Cambiar a este' : 'Suscribirme' }}</span>
               </button>
-              <div v-else class="text-center text-xs font-bold text-blue-600 py-2">Plan actual</div>
+              <div v-else class="text-center text-xs font-bold text-blue-600 py-2 flex items-center justify-center gap-1">
+                <CheckCircle2 class="w-4 h-4" aria-hidden="true" />
+                Plan actual
+              </div>
             </div>
           </div>
 
@@ -146,6 +170,19 @@ import api from '@/axios'
 import Swal from 'sweetalert2'
 import dayjs from 'dayjs'
 import { SWAL_COLORS } from '@/lib/colors'
+import {
+  Home,
+  Loader2,
+  AlertCircle,
+  Calendar,
+  CalendarX,
+  Clock,
+  Check,
+  CheckCircle2,
+  RefreshCw,
+  X,
+  Package,
+} from 'lucide-vue-next'
 
 const loading  = ref(true)
 const saving   = ref(false)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Reemplazo de iconos SVG y emojis por componentes Lucide

Se refactorizó la interfaz para eliminar iconos SVG en línea y emojis, reemplazándolos por componentes de `lucide-vue-next` y mejorando la consistencia visual y mantenibilidad.

### Cambios principales

- Dependencias y configuración:
  - Se añadió `lucide-vue-next` (^1.0.0) en package.json.
  - Se agregó `.claude/settings.local.json` (configuración local con permisos para comandos específicos).

- Componentes y vistas actualizados (selección representativa):
  - UI compartida: `BaseSelect.vue` fue refactorizado de `<select>` nativo a un dropdown custom con búsqueda/filtrado, manejo de clic fuera, y props `searchable` / `emptyText`. `BaseModal.vue` reemplazó el icono de cierre por el componente `X`.
  - Miembros: `MemberRegisterModal.vue`, `MemberDetailModal.vue`, `MemberPaymentModal.vue`, `MemberAssignModal.vue` — iconos reemplazados por Lucide; algunos selects convertidos a `BaseSelect`.
  - Vistas principales: `Members.vue`, `Membership.vue`, `MembershipPlans.vue`, `Products.vue`, `InventoryLog.vue`, `Payments.vue`, `POS.vue`, `CashBox.vue`, `AccessLogs.vue`, `Statistics.vue`, `Subscription.vue`, `Configuracion.vue`, `FingerprintKiosk.vue`, `FingerprintEnroll.vue`, `MemberDetail.vue`, `MemberEdit.vue`, `Sidebar.vue`, `Menu.vue`, `Login.vue`, `Register.vue`, `RegisterMember.vue`, `PublicRegister.vue` — múltiples iconos/emoji reemplazados por componentes Lucide y mejoras en estados de carga y botones.
  - Paginación, botones de acción y estados de carga en muchas vistas ahora usan iconos Lucide (ChevronLeft/Right, Loader2, Check, X, etc.).

### Alcance técnico

- Componentes/vistas afectadas: 30+ (cambios mayoritariamente en templates e imports).
- Tipo de cambio: Refactorización UI (iconografía y componentes de UI).
- Lógica de negocio: Sin cambios en lógica, llamadas a APIs o manejo de errores.
- Interfaz pública: No se modificaron firmas públicas (props/emits) relevantes en los componentes.

### Notas de revisión

- Revisar que todas las importaciones de `lucide-vue-next` estén incluidas y que no queden iconos SVG/emoji residuales.
- Verificar accesibilidad (aria-labels/aria-hidden) en botones con iconos dinámicos y en toggles de visibilidad de contraseña.
- Validar comportamiento y estilos del nuevo `BaseSelect` en todos los lugares donde se reemplazó un `<select>` nativo.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->